### PR TITLE
fix: register plugin with Claude Code during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -457,6 +457,58 @@ if [[ -d "$CACHE_DIR" ]]; then
   ok "Cleared plugin cache (will rebuild on next launch)"
 fi
 
+# ── Register with Claude Code ────────────────────────────────────────────────
+# Claude Code discovers plugins via two JSON files:
+#   1. known_marketplaces.json — lists all marketplace sources
+#   2. installed_plugins.json — lists all installed plugins with paths
+
+header "Claude Code registration"
+
+KNOWN_MARKETPLACES="$HOME/.claude/plugins/known_marketplaces.json"
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+MARKETPLACE_ROOT="$HOME/.claude/plugins/local-plugins"
+
+if command -v jq &>/dev/null; then
+  # Step 1: Register "local" marketplace in known_marketplaces.json
+  if [[ ! -f "$KNOWN_MARKETPLACES" ]]; then
+    echo '{}' > "$KNOWN_MARKETPLACES"
+  fi
+  TMPFILE="$(mktemp)"
+  jq --arg path "$MARKETPLACE_ROOT" --arg now "$NOW" \
+    '.local = {
+      "source": {"source": "directory", "path": $path},
+      "installLocation": $path,
+      "lastUpdated": $now
+    }' "$KNOWN_MARKETPLACES" > "$TMPFILE"
+  mv "$TMPFILE" "$KNOWN_MARKETPLACES"
+  ok "Registered 'local' marketplace with Claude Code"
+
+  # Step 2: Register plugin in installed_plugins.json
+  INSTALLED_PLUGINS="$HOME/.claude/plugins/installed_plugins.json"
+  PLUGIN_KEY="$PLUGIN_NAME@local"
+
+  if [[ ! -f "$INSTALLED_PLUGINS" ]]; then
+    jq -n '{"version": 2, "plugins": {}}' > "$INSTALLED_PLUGINS"
+  fi
+  TMPFILE="$(mktemp)"
+  jq --arg key "$PLUGIN_KEY" \
+     --arg path "$INSTALL_DIR" \
+     --arg version "$PLUGIN_VERSION" \
+     --arg now "$NOW" \
+     '.plugins[$key] = [{
+       "scope": "user",
+       "installPath": $path,
+       "version": $version,
+       "installedAt": $now,
+       "lastUpdated": $now
+     }]' "$INSTALLED_PLUGINS" > "$TMPFILE"
+  mv "$TMPFILE" "$INSTALLED_PLUGINS"
+  ok "Registered $PLUGIN_KEY in Claude Code"
+else
+  warn "jq not found — cannot register plugin with Claude Code"
+  info "  After installing jq, re-run this installer or run: claude /install"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 header "Done"

--- a/install.sh
+++ b/install.sh
@@ -458,15 +458,21 @@ if [[ -d "$CACHE_DIR" ]]; then
 fi
 
 # ── Register with Claude Code ────────────────────────────────────────────────
-# Claude Code discovers plugins via two JSON files:
-#   1. known_marketplaces.json — lists all marketplace sources
-#   2. installed_plugins.json — lists all installed plugins with paths
+# Claude Code discovers plugins via three data structures:
+#   1. known_marketplaces.json — lists marketplace sources
+#   2. installed_plugins.json — lists installed plugins with versioned cache paths
+#   3. settings.json — enabledPlugins gate (plugin must be enabled to load)
+# The plugin files must also be copied to the versioned cache directory.
 
 header "Claude Code registration"
 
 KNOWN_MARKETPLACES="$HOME/.claude/plugins/known_marketplaces.json"
+INSTALLED_PLUGINS="$HOME/.claude/plugins/installed_plugins.json"
+SETTINGS_FILE="$HOME/.claude/settings.json"
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
 MARKETPLACE_ROOT="$HOME/.claude/plugins/local-plugins"
+PLUGIN_KEY="$PLUGIN_NAME@local"
+VERSIONED_CACHE="$HOME/.claude/plugins/cache/local/$PLUGIN_NAME/$PLUGIN_VERSION"
 
 if command -v jq &>/dev/null; then
   # Step 1: Register "local" marketplace in known_marketplaces.json
@@ -481,18 +487,20 @@ if command -v jq &>/dev/null; then
       "lastUpdated": $now
     }' "$KNOWN_MARKETPLACES" > "$TMPFILE"
   mv "$TMPFILE" "$KNOWN_MARKETPLACES"
-  ok "Registered 'local' marketplace with Claude Code"
+  ok "Registered 'local' marketplace"
 
-  # Step 2: Register plugin in installed_plugins.json
-  INSTALLED_PLUGINS="$HOME/.claude/plugins/installed_plugins.json"
-  PLUGIN_KEY="$PLUGIN_NAME@local"
+  # Step 2: Copy plugin to versioned cache (Claude Code loads from cache)
+  mkdir -p "$VERSIONED_CACHE"
+  rsync -a --delete --exclude='.git' "$INSTALL_DIR/" "$VERSIONED_CACHE/"
+  ok "Cached plugin at $VERSIONED_CACHE"
 
+  # Step 3: Register plugin in installed_plugins.json (must point to cache)
   if [[ ! -f "$INSTALLED_PLUGINS" ]]; then
     jq -n '{"version": 2, "plugins": {}}' > "$INSTALLED_PLUGINS"
   fi
   TMPFILE="$(mktemp)"
   jq --arg key "$PLUGIN_KEY" \
-     --arg path "$INSTALL_DIR" \
+     --arg path "$VERSIONED_CACHE" \
      --arg version "$PLUGIN_VERSION" \
      --arg now "$NOW" \
      '.plugins[$key] = [{
@@ -503,7 +511,17 @@ if command -v jq &>/dev/null; then
        "lastUpdated": $now
      }]' "$INSTALLED_PLUGINS" > "$TMPFILE"
   mv "$TMPFILE" "$INSTALLED_PLUGINS"
-  ok "Registered $PLUGIN_KEY in Claude Code"
+  ok "Registered $PLUGIN_KEY in installed plugins"
+
+  # Step 4: Enable plugin in settings.json (required for Claude Code to load it)
+  if [[ ! -f "$SETTINGS_FILE" ]]; then
+    echo '{}' > "$SETTINGS_FILE"
+  fi
+  TMPFILE="$(mktemp)"
+  jq --arg key "$PLUGIN_KEY" \
+     '.enabledPlugins[$key] = true' "$SETTINGS_FILE" > "$TMPFILE"
+  mv "$TMPFILE" "$SETTINGS_FILE"
+  ok "Enabled $PLUGIN_KEY in settings"
 else
   warn "jq not found — cannot register plugin with Claude Code"
   info "  After installing jq, re-run this installer or run: claude /install"


### PR DESCRIPTION
## Summary

- The installer clones the plugin and creates `local-plugins/.claude-plugin/marketplace.json`, but Claude Code never discovers it because two registration files are missing
- After install, `/prfaq` returns **"Unknown skill: prfaq"** — the plugin is on disk but invisible to Claude Code
- Adds a new "Claude Code registration" section to `install.sh` that writes both `~/.claude/plugins/known_marketplaces.json` (marketplace source) and `~/.claude/plugins/installed_plugins.json` (plugin entry)

## Details

Claude Code discovers plugins through two JSON files:

1. **`known_marketplaces.json`** — lists all marketplace sources (GitHub repos, local directories)
2. **`installed_plugins.json`** — lists all installed plugins with paths and versions

The installer was writing neither. This PR adds a section (after cache-clear, before summary) that uses `jq` to register the `local` marketplace and the `prfaq@local` plugin entry.

### Edge cases handled
- **Files don't exist** → created with minimal valid structure
- **Re-running installer** → jq overwrites the entry (idempotent)
- **No jq** → warns and suggests re-running after installing jq (matches existing pattern)
- **Other marketplaces/plugins** → only touches `local` and `prfaq@local` keys

## Test plan

- [ ] Fresh install: delete `~/.claude/plugins/local-plugins` and both JSON files, run installer, verify `/prfaq` works in a new Claude Code session
- [ ] Re-run: run installer again, verify JSON files are updated (not duplicated) and `/prfaq` still works
- [ ] Without jq: temporarily hide jq from PATH, run installer, verify warning is shown and no crash
- [ ] Existing plugins: verify other marketplace/plugin entries in the JSON files are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Installer now writes/overwrites Claude Code config files and copies plugin contents into a versioned cache path, so mistakes could break existing plugin discovery or settings on a user machine.
> 
> **Overview**
> Fixes post-install plugin invisibility by having `install.sh` explicitly register the local marketplace and the installed plugin with Claude Code.
> 
> The installer now (when `jq` is available) creates/updates `~/.claude/plugins/known_marketplaces.json`, copies the plugin into a versioned cache directory, writes an entry into `~/.claude/plugins/installed_plugins.json` pointing at that cache, and enables the plugin in `~/.claude/settings.json`; if `jq` is missing it warns and skips registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f81ef8de3b1353266eb1f3c21c7ef6152fff987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->