### PR TITLE
Fix shellcheck SC2218 in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,14 @@ PLUGINS_DIR="$HOME/.claude/plugins/local-plugins/plugins"
 MARKETPLACE="$HOME/.claude/plugins/local-plugins/.claude-plugin/marketplace.json"
 INSTALL_DIR="$PLUGINS_DIR/$PLUGIN_NAME"
 
+# --- Helpers (must be defined before first use) --------------------------------
+
+info()   { printf '\033[0;34m%s\033[0m\n' "$*"; }
+ok()     { printf '\033[0;32m  ✓ %s\033[0m\n' "$*"; }
+warn()   { printf '\033[0;33m  ⚠ %s\033[0m\n' "$*"; }
+fail()   { printf '\033[0;31m  ✗ %s\033[0m\n' "$*"; }
+header() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+
 # Resolve the latest release tag (vX.Y.Z) via git ls-remote
 resolve_latest_tag() {
   git ls-remote --tags --sort=-v:refname "$REPO" 'v*' 2>/dev/null \
@@ -42,12 +50,6 @@ REQUIRED_PACKAGES=(
   changepage      # adjustwidth for indented FAQ answers
   biblatex        # Citation support
 )
-
-info()   { printf '\033[0;34m%s\033[0m\n' "$*"; }
-ok()     { printf '\033[0;32m  ✓ %s\033[0m\n' "$*"; }
-warn()   { printf '\033[0;33m  ⚠ %s\033[0m\n' "$*"; }
-fail()   { printf '\033[0;31m  ✗ %s\033[0m\n' "$*"; }
-header() { printf '\n\033[1m%s\033[0m\n' "$*"; }
 
 # Ask a yes/no question. Returns 0 for yes, 1 for no.
 ask() {


### PR DESCRIPTION
## Summary
- Move helper functions (`info`, `ok`, `warn`, `fail`, `header`) above their first call site
- Fixes shellcheck SC2218: function used before defined

## Test plan
- [ ] `shellcheck install.sh` passes clean
- [ ] `curl -fsSL ... | bash` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a reordering of shell helper function definitions with no logic changes to installation flow.
> 
> **Overview**
> Fixes a ShellCheck `SC2218` warning in `install.sh` by moving the output helper functions (`info`, `ok`, `warn`, `fail`, `header`) above their first call site.
> 
> No functional behavior changes intended; this is a small script-structure reorder to satisfy static analysis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4dc7d0c1c0b9bf7efd48e31e3ce788ba0b09d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->