### PR TITLE
ci: add markdown lint workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+      - run: npx markdownlint-cli2 "**/*.md" "#node_modules"

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,26 @@
+{
+  // List indentation — nested lists in command files use intentional indentation
+  "MD007": false,
+  // Multiple blank lines — used for visual separation in prompts
+  "MD012": false,
+  // Disable line length — tables, URLs, and descriptions routinely exceed any limit
+  "MD013": false,
+  // Blanks around headings — prompt files use compact formatting
+  "MD022": false,
+  // Duplicate headings — repeated section names are expected in skill/agent files
+  "MD024": false,
+  // Ordered list prefix — FAQ numbering is intentional (5, 6, 7... not 1, 2, 3)
+  "MD029": false,
+  // Blanks around fences — prompt files embed code blocks inline
+  "MD031": false,
+  // Blanks around lists — prompt files use tight list formatting
+  "MD032": false,
+  // Emphasis as heading — reference docs use emphasis for attribution
+  "MD036": false,
+  // Fenced code language — example blocks in prompts don't always need a language
+  "MD040": false,
+  // First line heading — agent/skill prompts start with persona text, not headings
+  "MD041": false,
+  // Disable table column style — compact pipes are fine
+  "MD060": false
+}


### PR DESCRIPTION
## Summary
- Adds docs.yml workflow per punt-kit github.md standard (punt-kit-h11)
- markdownlint-cli2 validates all .md files on push/PR to main
- .markdownlint.jsonc config tuned for plugin prompt content (disables style rules that conflict with LLM prompt formatting)
- Actions pinned to full SHA

## Test plan
- [ ] CI run passes on this PR (docs job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds Markdown linting and a config file; risk is limited to potential CI failures from newly enforced lint rules.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/docs.yml`) that runs on pushes and PRs to `main` and lints all `**/*.md` files via `markdownlint-cli2` on Node 20 (actions pinned to SHAs).
> 
> Introduces `.markdownlint.jsonc` to tune markdownlint for prompt-style docs by disabling several style-focused rules (e.g., list indentation, blank lines, line length, duplicate headings, fenced code language).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87bbde1a37160b7748e53e8537c8d7ae4f8035a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->