### PR TITLE
fix: add SSH fallback to install.sh, apply dev naming

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
-  "name": "prfaq",
+  "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process — generate professional LaTeX documents for product discovery and decision-making",
   "version": "1.2.0",
   "author": {
-    "name": "punt-labs",
+    "name": "Punt Labs",
     "email": "hello@punt-labs.com"
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -45,14 +45,38 @@ else
   ok "marketplace registered"
 fi
 
-# --- Step 3: Install plugin ---
+# --- Step 3: SSH fallback for plugin install ---
+
+# claude plugin install clones via SSH (git@github.com:...).
+# Users without SSH keys need an HTTPS fallback.
+NEED_HTTPS_REWRITE=0
+cleanup_https_rewrite() {
+  if [ "$NEED_HTTPS_REWRITE" = "1" ]; then
+    git config --global --unset url."https://github.com/".insteadOf 2>/dev/null || true
+    NEED_HTTPS_REWRITE=0
+  fi
+}
+trap cleanup_https_rewrite EXIT INT TERM
+
+if ! ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+  warn "SSH auth to GitHub unavailable, using HTTPS fallback"
+  git config --global url."https://github.com/".insteadOf "git@github.com:"
+  NEED_HTTPS_REWRITE=1
+fi
+
+# --- Step 4: Install plugin ---
 
 info "Installing $PLUGIN_NAME..."
 
-claude plugin install "${PLUGIN_NAME}@${MARKETPLACE_NAME}" || fail "Failed to install $PLUGIN_NAME"
+if ! claude plugin install "${PLUGIN_NAME}@${MARKETPLACE_NAME}"; then
+  cleanup_https_rewrite
+  fail "Failed to install $PLUGIN_NAME"
+fi
 ok "$PLUGIN_NAME installed"
 
-# --- Step 4: TeX distribution check ---
+cleanup_https_rewrite
+
+# --- Step 5: TeX distribution check ---
 
 info "Checking TeX distribution (optional, needed for PDF output)..."
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ else
   BOLD='' GREEN='' YELLOW='' NC=''
 fi
 
-info() { printf '%b==>%b %s\n' "$BOLD" "$NC" "$1"; }
+info() { printf '%b▶%b %s\n' "$BOLD" "$NC" "$1"; }
 ok()   { printf '  %b✓%b %s\n' "$GREEN" "$NC" "$1"; }
 warn() { printf '  %b!%b %s\n' "$YELLOW" "$NC" "$1"; }
 fail() { printf '  %b✗%b %s\n' "$YELLOW" "$NC" "$1"; exit 1; }


### PR DESCRIPTION
## Summary
- Add SSH→HTTPS git rewrite for users without GitHub SSH keys (matches z-spec pattern)
- Rename plugin to `prfaq-dev` for dev/prod isolation
- Fix author field casing to "Punt Labs"

## Test plan
- [ ] Run `shellcheck --shell=sh install.sh` (passes)
- [ ] Verify install works with SSH keys available
- [ ] Verify install falls back to HTTPS without SSH keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies installer behavior by temporarily rewriting global git URL rules, which could affect other git operations if cleanup fails, but scope is limited to install-time scripting.
> 
> **Overview**
> Renames the plugin package to `prfaq-dev` and normalizes the author name capitalization in `.claude-plugin/plugin.json`.
> 
> Updates `install.sh` to detect missing GitHub SSH authentication and temporarily rewrite `git@github.com:` to `https://github.com/` during `claude plugin install`, with cleanup via `trap` and explicit teardown after install; also tweaks the installer’s status output prefix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b5a5037a56df1e371098ddf7f686f9d962fb8a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->