### PR TITLE
feat: add plugin permissions to installer

### DIFF
--- a/commands/badge.md
+++ b/commands/badge.md
@@ -1,6 +1,7 @@
 ---
 description: Generate a stage-colored badge and embed it in your README
 argument-hint: "[path/to/prfaq.tex]"
+allowed-tools: Read, Write, Edit, Glob, Grep
 ---
 
 # Embed PR/FAQ Badge in README

--- a/commands/externalize.md
+++ b/commands/externalize.md
@@ -1,6 +1,7 @@
 ---
 description: Generate an external press release from the PR/FAQ and CHANGELOG for a specific release
 argument-hint: "[version, e.g. v2.0]"
+allowed-tools: Bash(bash */compile_prfaq.sh *), Read, Write, Glob, Grep
 ---
 
 # Externalize: PR/FAQ → Press Release

--- a/commands/feedback-to-us.md
+++ b/commands/feedback-to-us.md
@@ -1,5 +1,6 @@
 ---
 description: Tell us how the prfaq plugin is working for you (anonymous 1-5 feedback)
+allowed-tools: Bash(uuidgen), Bash(curl *), Read, Write, Glob, Grep
 ---
 
 # Feedback to Us

--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -1,6 +1,7 @@
 ---
 description: Incorporate feedback into PR/FAQ and redraft affected sections
 argument-hint: "[feedback text or path/to/meeting-summary.md]"
+allowed-tools: Bash(bash */compile_prfaq.sh *), Read, Edit, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Incorporate Feedback into PR/FAQ

--- a/commands/import.md
+++ b/commands/import.md
@@ -1,6 +1,7 @@
 ---
 description: Import an existing document and launch the full /prfaq workflow with extracted content
 argument-hint: "[path/to/document.md or paste text directly]"
+allowed-tools: Bash(bash */compile_prfaq.sh *), Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Import Document into PR/FAQ

--- a/commands/meeting-hive.md
+++ b/commands/meeting-hive.md
@@ -1,6 +1,7 @@
 ---
 description: Run an autonomous PR/FAQ review meeting where four personas debate and reach consensus without user intervention
 argument-hint: "[path/to/prfaq.tex]"
+allowed-tools: Bash(mkdir -p meetings), Read, Write, Glob, Grep
 ---
 
 # PR/FAQ Hive Meeting

--- a/commands/meeting.md
+++ b/commands/meeting.md
@@ -1,6 +1,7 @@
 ---
 description: Run a simulated PR/FAQ review meeting with agentic personas
 argument-hint: "[path/to/prfaq.tex]"
+allowed-tools: Bash(mkdir -p meetings), Read, Write, Glob, Grep
 ---
 
 # PR/FAQ Review Meeting

--- a/commands/research.md
+++ b/commands/research.md
@@ -1,6 +1,7 @@
 ---
 description: Research evidence for PR/FAQ claims and generate biblatex citations
 argument-hint: "[claim or topic or path/to/prfaq.tex]"
+allowed-tools: Bash(mkdir -p research), Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Research Evidence for PR/FAQ

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,6 +1,7 @@
 ---
 description: Peer review a PR/FAQ document for quality and decision readiness
 argument-hint: "[path/to/prfaq.tex]"
+allowed-tools: Read, Edit, Glob, Grep, WebSearch, WebFetch
 ---
 
 # Peer Review PR/FAQ

--- a/commands/streamline.md
+++ b/commands/streamline.md
@@ -1,6 +1,7 @@
 ---
 description: Tighten a PR/FAQ by removing redundancy, weasel words, and bloat
 argument-hint: "[optional: section to focus on]"
+allowed-tools: Bash(bash scripts/compile_prfaq.sh *), Read, Edit, Glob, Grep
 ---
 
 # Streamline PR/FAQ

--- a/commands/streamline.md
+++ b/commands/streamline.md
@@ -1,7 +1,7 @@
 ---
 description: Tighten a PR/FAQ by removing redundancy, weasel words, and bloat
 argument-hint: "[optional: section to focus on]"
-allowed-tools: Bash(bash scripts/compile_prfaq.sh *), Read, Edit, Glob, Grep
+allowed-tools: Bash(bash */compile_prfaq.sh *), Read, Edit, Glob, Grep
 ---
 
 # Streamline PR/FAQ

--- a/commands/vote.md
+++ b/commands/vote.md
@@ -1,6 +1,7 @@
 ---
 description: Assess whether a PR/FAQ should move forward with a structured go/no-go decision
 argument-hint: "[path/to/prfaq.tex ...or multiple paths for portfolio comparison]"
+allowed-tools: Read, Write, Glob, Grep
 ---
 
 # Go/No-Go Decision: PR/FAQ Vote

--- a/install.sh
+++ b/install.sh
@@ -123,15 +123,22 @@ if command -v jq >/dev/null 2>&1; then
   if [ ! -f "$SETTINGS_FILE" ]; then
     mkdir -p "$(dirname "$SETTINGS_FILE")"
     printf '{}' > "$SETTINGS_FILE"
+  elif ! jq -e . "$SETTINGS_FILE" >/dev/null 2>&1; then
+    warn "Existing $SETTINGS_FILE contains invalid JSON; backing up and recreating"
+    cp "$SETTINGS_FILE" "${SETTINGS_FILE}.bak" 2>/dev/null || true
+    printf '{}' > "$SETTINGS_FILE"
   fi
 
-  # Count existing rules, merge atomically, count new total
-  BEFORE=$(jq '.permissions.allow // [] | length' "$SETTINGS_FILE")
-  jq --argjson new "$PRFAQ_RULES" \
-    '.permissions.allow = ((.permissions.allow // []) + $new | unique)' \
-    "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
-  AFTER=$(jq '.permissions.allow | length' "$SETTINGS_FILE")
-  ADDED=$((AFTER - BEFORE))
+  # Order-preserving merge: append only rules not already present
+  ADDED=$(jq -r --argjson new "$PRFAQ_RULES" '
+    (.permissions.allow // []) as $orig
+    | [$new[] | select(. as $r | $orig | index($r) | not)] | length
+  ' "$SETTINGS_FILE")
+
+  jq --argjson new "$PRFAQ_RULES" '
+    (.permissions.allow // []) as $orig
+    | .permissions.allow = $orig + [$new[] | select(. as $r | $orig | index($r) | not)]
+  ' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
 
   if [ "$ADDED" -gt 0 ]; then
     ok "$ADDED permission rule(s) added to $SETTINGS_FILE"
@@ -141,7 +148,7 @@ if command -v jq >/dev/null 2>&1; then
 else
   warn "jq not found — cannot auto-configure permissions"
   printf '\n'
-  info "Add these rules manually to %s under permissions.allow:" "$SETTINGS_FILE"
+  info "Add these rules manually to $SETTINGS_FILE under permissions.allow:"
   printf '%s\n' "$PRFAQ_RULES"
   printf '\n'
 fi

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,66 @@ ok "$PLUGIN_NAME installed"
 
 cleanup_https_rewrite
 
-# --- Step 5: TeX distribution check ---
+# --- Step 5: Configure permissions ---
+
+info "Configuring plugin permissions..."
+
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+# Permission rules the plugin needs to operate without constant prompts.
+# Deliberately excluded: Bash(curl *) and all Bash(rm *) — those require manual approval.
+PRFAQ_RULES='[
+  "Bash(bash */compile_prfaq.sh *)",
+  "Bash(bash scripts/compile_prfaq.sh *)",
+  "Bash(uuidgen)",
+  "Bash(mkdir -p meetings)",
+  "Bash(mkdir -p research)",
+  "Write(*prfaq*.tex)",
+  "Write(*prfaq*.bib)",
+  "Write(press-release-*.tex)",
+  "Write(.claude/prfaq.local.md)",
+  "Write(meetings/**)",
+  "Write(research/**)",
+  "Write(.gitignore)",
+  "Write(README.md)",
+  "Edit(*prfaq*.tex)",
+  "Edit(*prfaq*.bib)",
+  "Edit(press-release-*.tex)",
+  "Edit(README.md)",
+  "Edit(.gitignore)",
+  "WebSearch",
+  "WebFetch"
+]'
+
+if command -v jq >/dev/null 2>&1; then
+  # Ensure settings file exists with valid JSON
+  if [ ! -f "$SETTINGS_FILE" ]; then
+    mkdir -p "$(dirname "$SETTINGS_FILE")"
+    printf '{}' > "$SETTINGS_FILE"
+  fi
+
+  # Count existing rules, merge atomically, count new total
+  BEFORE=$(jq '.permissions.allow // [] | length' "$SETTINGS_FILE")
+  jq --argjson new "$PRFAQ_RULES" \
+    '.permissions.allow = ((.permissions.allow // []) + $new | unique)' \
+    "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
+  AFTER=$(jq '.permissions.allow | length' "$SETTINGS_FILE")
+  ADDED=$((AFTER - BEFORE))
+
+  if [ "$ADDED" -gt 0 ]; then
+    ok "$ADDED permission rule(s) added to $SETTINGS_FILE"
+  else
+    ok "permissions already configured"
+  fi
+else
+  warn "jq not found — cannot auto-configure permissions"
+  printf '\n'
+  info "Add these rules manually to %s under permissions.allow:" "$SETTINGS_FILE"
+  printf '%s\n' "$PRFAQ_RULES"
+  printf '\n'
+fi
+
+# --- Step 6: TeX distribution check ---
 
 info "Checking TeX distribution (optional, needed for PDF output)..."
 

--- a/skills/prfaq/SKILL.md
+++ b/skills/prfaq/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prfaq
+allowed-tools: Bash(bash */compile_prfaq.sh *), Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 description: >
   This skill should be used when the user asks to "write a PR/FAQ",
   "prfaq", "working backwards", "product discovery", "evaluate a product idea",


### PR DESCRIPTION
## Summary

- Installer now injects 20 specific permission rules into `~/.claude/settings.json` (new Step 5), eliminating constant approval prompts for compile, write, edit, and web search operations
- Uses `jq` for atomic idempotent merge; falls back to printing rules for manual addition when `jq` unavailable
- All 12 command/skill files gain `allowed-tools` frontmatter (currently bugged in Claude Code issues #14956/#18837, but future-proofs and documents intent)

## Design decisions

- **Deliberately excludes** `Bash(curl *)` and `Bash(rm *)` — network POSTs and file deletion still require manual approval
- **Idempotent** — re-running the installer adds 0 duplicate rules (verified)
- **Non-destructive** — only adds rules, never removes existing user permissions

## Test plan

- [x] Quality gate: `prfaq.tex` compiles
- [x] Quality gate: `prfaq-template.tex` compiles
- [x] Permission injection adds correct rules to `settings.json`
- [x] Re-running is idempotent (0 new rules on second run)
- [ ] Fresh install on clean `settings.json` (creates file if missing)
- [ ] `jq` fallback path prints correct manual instructions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the installer to write/merge allowlisted permissions into the user’s `~/.claude/settings.json`, which affects local security posture and could mis-handle existing/invalid settings JSON. Changes are otherwise scoped to configuration/frontmatter updates and are low complexity.
> 
> **Overview**
> Adds an installer step that *auto-configures Claude Code permissions* by idempotently merging a `permissions.allow` ruleset into `~/.claude/settings.json` via `jq`, with a manual-copy fallback when `jq` isn’t available.
> 
> Updates all PR/FAQ command markdown files and the `prfaq` skill to declare `allowed-tools` in frontmatter, documenting/aligning the intended tool access for each command (while still keeping `curl`/`rm` excluded from the installer auto-allowlist).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e9aa304c9242f88cf7b1f2e6ec9bff12834a8cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->