### PR TITLE
fix: update install.sh SHA in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Fourteen commands form a complete product-thinking workflow:
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/a4d30cc/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/869c473/install.sh | sh
 ```
 
 <details>
@@ -63,7 +63,7 @@ claude plugin install prfaq@punt-labs
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/a4d30cc/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/869c473/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh


### PR DESCRIPTION
Old SHA `a4d30cc` predated the SSH→HTTPS fallback, causing install failures on machines without GitHub SSH keys configured.

Updates to `869c473` which includes the SSH fallback logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the pinned `install.sh` commit reference; no runtime code changes.
> 
> **Overview**
> Updates the README installation commands to fetch `install.sh` from a newer pinned commit (`869c473` instead of `a4d30cc`), including the “verify before running” snippet, to prevent installs from using an outdated script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc94a5f957dea38e6af4b85566565da0e4aaf05d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->