### PR TITLE
fix: batch meeting-listen unmute calls into segments

### DIFF
--- a/commands/meeting-listen.md
+++ b/commands/meeting-listen.md
@@ -122,21 +122,33 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
    **Priya:** Which of those developers am I?
    ```
 
-   **In voiced mode**, also call `mcp__plugin_vox_mic__unmute` for each line with:
-   - `text`: The dialogue line text only (without the speaker label — labels are for reading, not speaking)
-   - `voice`: The resolved voice for this persona (from step 3/4)
+   **In voiced mode**, after printing all dialogue lines for the hot spot, make a single `mcp__plugin_vox_mic__unmute` call with:
    - `ephemeral`: `true`
-   - `vibe_tags` (ElevenLabs only): The persona's `voice_vibe` value. For emotionally charged lines, use situational tags instead:
-     - Wei finding handwaving: `[frustrated]`
-     - Priya losing patience with jargon: `[frustrated]`
-     - Alex pattern-matching to a past failure: `[sighs]`
-     - Dana seeing the bigger opportunity: `[excited]`
-     - Any persona on a KEEP/vindicated moment: `[satisfied]`
-   - For non-ElevenLabs providers: omit `vibe_tags` entirely. Do NOT prepend tags to the text — they will be spoken literally.
+   - `segments`: An array of objects, one per dialogue line, each with:
+     - `text`: The dialogue line text only (without the speaker label — labels are for reading, not speaking)
+     - `voice`: The resolved voice for this persona (from step 3/4)
+     - `vibe_tags` (ElevenLabs only): The persona's `voice_vibe` value. For emotionally charged lines, use situational tags instead:
+       - Wei finding handwaving: `[frustrated]`
+       - Priya losing patience with jargon: `[frustrated]`
+       - Alex pattern-matching to a past failure: `[sighs]`
+       - Dana seeing the bigger opportunity: `[excited]`
+       - Any persona on a KEEP/vindicated moment: `[satisfied]`
+     - For non-ElevenLabs providers: omit `vibe_tags` from segments entirely. Do NOT prepend tags to the text — they will be spoken literally.
+
+   Example (ElevenLabs):
+   ```
+   unmute(
+       ephemeral: true,
+       segments: [
+           {"voice": "yu", "text": "The denominator is missing.", "vibe_tags": "[slow]"},
+           {"voice": "nila", "text": "Which of those developers am I?", "vibe_tags": "[frustrated]"},
+           {"voice": "bill", "text": "Compared to what?", "vibe_tags": "[sighs]"},
+           {"voice": "river", "text": "You're thinking too small.", "vibe_tags": "[excited]"}
+       ]
+   )
+   ```
 
    **In text-only mode**, just print the labeled lines. No TTS calls.
-
-   Wait for all lines in one hot spot to finish before moving to the next.
 
 6. **Close the playback.** After all hot spots, print:
 

--- a/commands/meeting-listen.md
+++ b/commands/meeting-listen.md
@@ -124,7 +124,20 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
 
    **In voiced mode**, after printing all dialogue lines for the hot spot, make a single `mcp__plugin_vox_mic__unmute` call with:
    - `ephemeral`: `true`
-   - `segments`: An array of objects, one per dialogue line, each with:
+   - `segments`: An array starting with a **narrator segment**, then one segment per dialogue line:
+
+     **Narrator segment** (first in array):
+     - `text`: A scene-setter that orients the listener. Synthesize from the summary row:
+       - Name the hot spot and which part of the document it concerns
+       - For hive summaries: mention the door and the core tension from the resolution
+       - For interactive summaries: mention the severity and the gist of the rationale
+       - End with the decision outcome so the listener knows the frame
+       - Example: "Hot spot 3: Pricing model, in the customer FAQ section. The team debated whether per-seat pricing alienates small teams. They decided to revise."
+     - Keep it to 2-3 sentences — enough context to follow the debate, not a full recap
+     - Omit `voice` — uses the session default, naturally distinguishing the narrator from persona voices
+     - Omit `vibe_tags`
+
+     **Dialogue segments** (one per line):
      - `text`: The dialogue line text only (without the speaker label — labels are for reading, not speaking)
      - `voice`: The resolved voice for this persona (from step 3/4)
      - `vibe_tags` (ElevenLabs only): The persona's `voice_vibe` value. For emotionally charged lines, use situational tags instead:
@@ -140,6 +153,7 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
    unmute(
        ephemeral: true,
        segments: [
+           {"text": "Hot spot 3: Pricing model, in the customer FAQ section. The team debated whether per-seat pricing alienates small teams. They decided to revise."},
            {"voice": "yu", "text": "The denominator is missing.", "vibe_tags": "[slow]"},
            {"voice": "nila", "text": "Which of those developers am I?", "vibe_tags": "[frustrated]"},
            {"voice": "bill", "text": "Compared to what?", "vibe_tags": "[sighs]"},


### PR DESCRIPTION
## Summary

- Adapt `/prfaq:meeting-listen` for vox's non-blocking `unmute` (v1.1.1+)
- Replace N per-line `unmute` calls per hot spot with a single batched call using the `segments` parameter
- Each segment carries its own `voice` and `vibe_tags`, preserving per-persona emotional variation
- Remove "wait for all lines to finish" instruction — vox's internal flock serialization handles ordering

## Context

Vox v1.1.1+ made `unmute` non-blocking (returns predicted metadata immediately, playback runs in background). Without this change, all dialogue text prints instantly while audio plays behind, losing the pacing between hot spots.

## Test plan

- [ ] Run `/prfaq:meeting-listen` with ElevenLabs active — confirm four distinct voices play sequentially per hot spot
- [ ] Run `/prfaq:meeting-listen` with a non-ElevenLabs provider — confirm vibe tags are not spoken literally
- [ ] Run `/prfaq:meeting-listen` without vox installed — confirm text-only fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/prfaq:meeting-listen` playback contract to use a single batched `unmute(segments=...)` call per hot spot, which could affect TTS pacing/voice tagging if the segments format or provider-specific `vibe_tags` handling is wrong.
> 
> **Overview**
> Updates `/prfaq:meeting-listen` to stop issuing one `mcp__plugin_vox_mic__unmute` call per dialogue line and instead emit **one** `unmute` per hot spot with a `segments` array.
> 
> The new `segments` payload starts with a short *narrator* scene-setter (no `voice`/`vibe_tags`), followed by one segment per persona line carrying its own `voice` and (ElevenLabs-only) `vibe_tags`, and it removes the instruction to wait between lines/hot spots to match vox’s non-blocking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2474925623006e99a39839b1a7d56060e47e5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->