### PR TITLE
chore: add full punt-labs peer list to .biff

### DIFF
--- a/.biff
+++ b/.biff
@@ -3,3 +3,6 @@ members = ["jmf-pobox"]
 
 [relay]
 url = "tls://connect.ngs.global"
+
+[peers]
+repos = ["punt-labs/.github", "punt-labs/beadle", "punt-labs/biff", "punt-labs/cryptd", "punt-labs/dungeon", "punt-labs/koch-trainer-swift", "punt-labs/langlearn-tts", "punt-labs/lux", "punt-labs/public-website", "punt-labs/punt-kit", "punt-labs/quarry", "punt-labs/quarry-menubar", "punt-labs/vox", "punt-labs/z-spec"]


### PR DESCRIPTION
Adds all punt-labs repos to `[peers]` so biff sessions can see agents across the org.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects peer visibility/discovery in biff sessions but does not touch runtime code or data handling.
> 
> **Overview**
> Adds a new `[peers]` configuration block in `.biff` that enumerates the full set of `punt-labs/*` repos, enabling biff sessions to discover and interact with agents across the org.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 783577f417f11d3ec0af5d82a08bd7c08a531e78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->