### PR TITLE
release: v1.6.1 — version bump and CHANGELOG

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process — generate professional LaTeX documents for product discovery and decision-making",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,7 +302,9 @@ First tagged release.
 - Plugin cache not clearing on reinstall (stale cache hid new agents)
 - FAQ paragraph indentation inconsistency in `faqpair` environment
 
-[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.5.2...HEAD
+[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/punt-labs/prfaq/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/punt-labs/prfaq/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/punt-labs/prfaq/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/punt-labs/prfaq/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/punt-labs/prfaq/compare/v1.4.0...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-03-20
+
 ### Added
 
 - `scripts/release-plugin.sh` and `scripts/restore-dev-plugin.sh` — automate the dev/prod name swap for releases, preventing the `-dev` name from leaking into tagged commits


### PR DESCRIPTION
## Summary

- Bump `plugin.json` version from 1.6.0 to 1.6.1
- Move CHANGELOG entries from Unreleased to v1.6.1 section

Tag `v1.6.1` is already pushed with the correct prod name (`prfaq`). This PR lands the version bump and CHANGELOG on main.

## Test plan

- [ ] Verify `v1.6.1` tag has `name: "prfaq"` (already confirmed)
- [ ] After merge, update marketplace `source.ref` to `v1.6.1`

Bead: prfaq-w65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates plugin metadata and CHANGELOG entries/compare links, with no runtime or behavior changes.
> 
> **Overview**
> Bumps `.claude-plugin/plugin.json` version from `1.6.0` to `1.6.1`.
> 
> Updates `CHANGELOG.md` by cutting a new `1.6.1` section (Added/Fixed notes) and adjusting compare links so **Unreleased** now compares from `v1.6.1` and includes the new `v1.6.0...v1.6.1` link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62c192178d258e8079326cb5c6022aa02256bc10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->