### PR TITLE
chore: add .envrc.local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ research/spike-voices/
 # Claude Code (settings.json is tracked; everything else is local/runtime)
 .claude/
 !.claude/settings.json
+.envrc.local


### PR DESCRIPTION
Adds `.envrc.local` to `.gitignore` to support the new `.envrc` / `.envrc.local` split.

## Summary
- `.envrc` is now portable (sources shared identity, sets TMPDIR and AGENT_TEAMS)
- `.envrc.local` holds machine-specific secrets (API keys, keychain refs)
- `.envrc.local` must be gitignored

## Test plan
- [ ] `direnv allow` loads both files
- [ ] `git status` does not show `.envrc.local`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.gitignore`, preventing accidental commits of machine-specific `direnv` secrets.
> 
> **Overview**
> Adds `.envrc.local` to `.gitignore` so machine-specific `direnv` configuration/secrets aren’t tracked, supporting a split between portable `.envrc` and local overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9c768164893647792f5d33f8168cd78c475d7e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->