### PR TITLE
chore(ethos): add ethos.yaml for identity resolution

### DIFF
--- a/.punt-labs/ethos.yaml
+++ b/.punt-labs/ethos.yaml
@@ -1,0 +1,2 @@
+agent: claude
+team: engineering


### PR DESCRIPTION
Add `.punt-labs/ethos.yaml` for ethos identity resolution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new configuration file under `.punt-labs` with no code-path changes; risk is limited to any tooling that consumes this config interpreting the new identity fields incorrectly.
> 
> **Overview**
> Adds `.punt-labs/ethos.yaml` to enable ethos identity resolution, setting `agent: claude` and `team: engineering`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f7a8e4b046cbfebf593adc3aad9df859d70a5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->