### PR TITLE
chore(envrc): track .envrc, gitignore .envrc.local

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# Shared punt-labs environment
+source "${HOME}/.punt-labs/git-identity.env"
+source_env_if_exists .envrc.local
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+export TMPDIR="$PWD/.tmp"
+mkdir -p "$TMPDIR"

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 *.fls
 *.fdb_latexmk
 .DS_Store
-.envrc
 
 # Runtime / scratch
 .tmp/


### PR DESCRIPTION
## Summary
- `.envrc` is now **tracked** (portable config, committed to git)
- `.envrc.local` is **gitignored** (machine-specific secrets)
- Removed `.envrc` from `.gitignore`
- Ensured `.envrc.local` is in `.gitignore`

## Test plan
- [ ] `git status` shows `.envrc` as tracked
- [ ] `git status` does not show `.envrc.local`
- [ ] `direnv allow` loads both files correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: repo-level dev environment/direnv configuration changes only, with no runtime application logic impact.
> 
> **Overview**
> Tracks a new shared `/.envrc` for `direnv`, loading a common `~/.punt-labs/git-identity.env`, optionally sourcing `.envrc.local`, and setting up a project-local `.tmp` `TMPDIR`.
> 
> Updates `.gitignore` to **stop ignoring** `.envrc` and to **ignore** `.envrc.local` (and related local Claude Code runtime files), keeping machine-specific settings out of git.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 345d735684170e99a208dcf8b12d6d90d0a2a6e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->