### PR TITLE
fix(permissions): add bare Read/Write/Edit rules to unblock sub-agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -114,7 +114,10 @@
       "Skill(z-spec:setup)",
       "Skill(z-spec:doctor)",
       "Skill(z-spec:help)",
-      "Skill(z-spec:cleanup)"
+      "Skill(z-spec:cleanup)",
+      "Read",
+      "Edit",
+      "Write"
     ],
     "deny": [
       "Bash(curl:*)",


### PR DESCRIPTION
Add bare Read/Write/Edit entries to .claude/settings.json so sub-agents delegated from the lead session can perform file operations without silent denial.

Sub-agents inherit the permissions allow list from settings.json. When Read/Write/Edit are not present as bare entries, the default tier is prompt, which auto-denies in non-interactive background sub-agent execution. Path-scoped forms (Read(../**)) are not honored by sub-agents in testing. The bare form is the only reliable unblock.

Tracks the three-incident history (2026-04-05, 2026-04-06, 2026-04-08) and the companion standards update in punt-labs/punt-kit#209.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands tool permissions by granting repo-wide `Read`/`Edit`/`Write` at the bare level, which can increase the blast radius of automated agents if misused. Change is small but affects security-sensitive access controls.
> 
> **Overview**
> Updates `.claude/settings.json` to explicitly allow bare `Read`, `Edit`, and `Write` operations (in addition to existing path-scoped variants) so non-interactive sub-agents aren’t silently denied basic file access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc44854071defad1005eed4291396ce451cb3a1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->