### PR TITLE
fix: remove broken permissions and fix docs.yml globs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,6 @@
   },
   "permissions": {
     "allow": [
-      "Read(../**)",
-      "Edit(../**)",
-      "Write(../**)",
       "Bash(bash:*)",
       "Bash(bd:*)",
       "Bash(cat:*)",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: DavidAnson/markdownlint-cli2-action@2256fe35224a451507c8848ec825a4212e9eeb00 # v22
         with:
-          globs: "**/*.md #node_modules"
+          globs: "**/*.md"
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 # Runtime / scratch
 .tmp/
 .tts/
-.vox/
 .biff.local
 
 # Binary assets (voice auditions, etc.)

--- a/.vox/config.md
+++ b/.vox/config.md
@@ -1,0 +1,7 @@
+---
+notify: "y"
+speak: "n"
+voice: "matilda"
+vibe_signals: ""
+vibe_tags: ""
+---


### PR DESCRIPTION
## Summary

- Remove broken `Read(../**)`, `Edit(../**)`, `Write(../**)` from `.claude/settings.json` (relative paths not supported; absolute-path versions in `settings.local.json` already work)
- Fix markdownlint glob in `docs.yml`: `"**/*.md #node_modules"` to `"**/*.md"` (space-separated exclusions not supported by markdownlint-cli2-action)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts local/tooling configuration (Claude Code permissions, markdownlint workflow, gitignore) with no runtime product code changes.
> 
> **Overview**
> Removes unsupported relative-path `Read/Edit/Write(../**)` entries from `.claude/settings.json` to avoid broken Claude Code permission rules.
> 
> Fixes the Docs GitHub Action markdownlint configuration by using a valid glob (`**/*.md`) instead of an inline exclusion string.
> 
> Stops ignoring `.vox/` in `.gitignore` and adds a tracked `.vox/config.md` with default `vox` settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21db82c56224b757de6cff1165416b4427bc2d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->