### PR TITLE
chore(envrc): inherit meta-repo env via source_up

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,6 @@
+# Inherit shared punt-labs environment (BEADS_DOLT_*, git identity, etc.) from the meta-repo .envrc.
+source_up
+
 # Shared punt-labs environment
 source "${HOME}/.punt-labs/git-identity.env"
 source_env_if_exists .envrc.local


### PR DESCRIPTION
Adds `source_up` to this repo's `.envrc` so direnv inherits the punt-labs meta-repo's exports (notably `BEADS_DOLT_*` for the central Hosted DoltDB connection).

Companion to the bd-detach-to-hosted migration. Generated by `.bin/envrc-source-up-rollout.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes local `direnv` initialization by adding `source_up`, which can affect developer environment variables but not runtime/production behavior.
> 
> **Overview**
> Updates `.envrc` to call `source_up` so this repo inherits environment exports from the parent meta-repo (e.g., shared `BEADS_DOLT_*` and git identity settings) before applying local overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a142a99a17ab4504752336b53248e8705eacf2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->