### PR TITLE
chore(beads): auto-scope bd via directory.labels; disable local backup/export

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -12,3 +12,21 @@
 # This file is intentionally minimal. Most legacy keys (no-db, no-daemon,
 # no-auto-flush, no-auto-import, sync-branch) were removed in bd 1.0+
 # and reading them would be misleading.
+
+# Auto-scope `bd list` to this repo's records via the central DB's
+# `repo:prfaq` label. The label is backfilled in the Hosted DoltDB.
+# Note: bd 1.0.4's `bd ready` does NOT honor directory.labels — use
+# `bd ready --label-any repo:prfaq` until upstream fixes that.
+directory:
+  labels:
+    prfaq: repo:prfaq
+
+# Source of truth is the central Hosted DoltDB. Local Dolt-native backups
+# and auto-exported JSONL views are noise that creates stale-state
+# confusion (and the backup remote registration hangs on Hosted DoltDB
+# because the server-side mkdir fails on a local-path string).
+backup:
+  enabled: false
+export:
+  auto: false
+  git-add: false


### PR DESCRIPTION
Adds 4 keys to `.beads/config.yaml` so plain `bd` commands from this repo work cleanly against the central Hosted DoltDB.

- `directory.labels.prfaq: repo:prfaq` — auto-scope `bd list` to this repo
- `backup.enabled: false` — stops the Hosted-DoltDB backup-remote registration that was hanging the command
- `export.auto: false` + `export.git-add: false` — stops `.beads/issues.jsonl` regen/git-add

Pattern proven on punt-labs/biff#242. The `repo:prfaq` label is already backfilled in the central DB.

Caveat: bd 1.0.4's `bd ready` does NOT honor `directory.labels` — use `bd ready --label-any repo:prfaq` until upstream fixes that.

Generated by `.bin/bd-config-rollout.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting local `bd` CLI behavior; primary risk is unexpected tooling workflow changes if someone relied on local backups or JSONL exports.
> 
> **Overview**
> Configures Beads (`.beads/config.yaml`) to automatically scope `bd list` to this repo via `directory.labels` (`repo:prfaq`).
> 
> Disables local Dolt backups and auto-export/git-add of JSONL views (`backup.enabled: false`, `export.auto: false`, `export.git-add: false`) to avoid hangs and stale local artifacts when using the central Hosted DoltDB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ef515ccfd393c29cb6ad68df14be67582e159c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->