### PR TITLE
chore(beads): full .beads/ conformance for central Hosted DoltDB

### DIFF
--- a/.beads/README.md
+++ b/.beads/README.md
@@ -12,8 +12,8 @@ in `.beads/metadata.json`.
   `issue_prefix`.
 - `.beads/issues.jsonl` and `.beads/interactions.jsonl` are local
   export views. Auto-export is disabled (`export.auto: false`);
-  run `bd export` manually if needed. They are
-  **gitignored** and not authoritative.
+  run `bd export` manually if needed. They are **gitignored** and
+  not authoritative.
 - `.beads/embeddeddolt/`, `backup/`, etc. are unused in server mode and
   gitignored.
 


### PR DESCRIPTION
Brings `.beads/` into full conformance with the central Hosted DoltDB setup:

- **config.yaml**: `directory.labels.prfaq: repo:prfaq` for auto-scoped `bd list`; `backup.enabled: false` (prevents server-side mkdir hang); `export.auto: false` + `export.git-add: false`
- **README.md**: updated to reflect auto-scoping, no auto-export
- **.gitignore**: synced to org template (blocks all runtime artifacts)
- **Untracked** any previously-tracked files now covered by .gitignore
- **Removed** stale beads merge driver from .gitattributes (if present)

Pattern proven on punt-labs/biff#242. The `repo:prfaq` label is already backfilled in the central DB.

Generated by `.bin/bd-config-rollout.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that reflows text in `.beads/README.md` without modifying any runtime behavior or configuration.
> 
> **Overview**
> Updates `.beads/README.md` to reflow the “Source of truth” section, clarifying that auto-export is disabled and `bd export` must be run manually, while keeping the note that local exports are **gitignored** and non-authoritative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2410ff975d9bf1bb725444c56800a7056106de8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->