### PR TITLE
chore: canonical .envrc with inline beads + platform secrets

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,9 +1,41 @@
-# Inherit shared punt-labs environment (BEADS_DOLT_*, git identity, etc.) from the meta-repo .envrc.
-source_up
+# Git identity (user-specific — name, email, signing key vary per contributor)
+if [ -f "${HOME}/.punt-labs/git-identity.env" ]; then
+  source "${HOME}/.punt-labs/git-identity.env"
+fi
 
-# Shared punt-labs environment
-source "${HOME}/.punt-labs/git-identity.env"
-source_env_if_exists .envrc.local
+# Beads — Hosted DoltDB connection
+export BEADS_DOLT_SERVER_HOST="punt-labs-beads-1.dbs.hosted.doltdb.com"
+export BEADS_DOLT_SERVER_PORT=3306
+export BEADS_DOLT_SERVER_USER="tacvb9o46xu04pa5"
+export BEADS_DOLT_SERVER_TLS=1
+
+# Secrets from platform-native secret store (service-name lookup only)
+case "$(uname -s)" in
+  Darwin)
+    export BEADS_DOLT_PASSWORD="$(security find-generic-password -s 'BEADS_DOLT_PASSWORD' -w 2>/dev/null)"
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s 'github-pat' -w 2>/dev/null)"
+    export ANTHROPIC_API_KEY="$(security find-generic-password -s 'ANTHROPIC_API_KEY' -w 2>/dev/null)"
+    export OPENAI_API_KEY="$(security find-generic-password -s 'OPENAI_API_KEY' -w 2>/dev/null)"
+    export ELEVENLABS_API_KEY="$(security find-generic-password -s 'elevenlabs-api-key' -w 2>/dev/null)"
+    export RESEND_API_KEY="$(security find-generic-password -s 'RESEND_API_KEY' -w 2>/dev/null)"
+    ;;
+  Linux)
+    export BEADS_DOLT_PASSWORD="$(pass show beads/dolt-password 2>/dev/null)"
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(pass show github/personal-access-token 2>/dev/null)"
+    export ANTHROPIC_API_KEY="$(pass show anthropic/api-key 2>/dev/null)"
+    export OPENAI_API_KEY="$(pass show openai/api-key 2>/dev/null)"
+    export ELEVENLABS_API_KEY="$(pass show elevenlabs/api-key 2>/dev/null)"
+    export RESEND_API_KEY="$(pass show resend/api-key 2>/dev/null)"
+    ;;
+esac
+
+export DISABLE_TELEMETRY=1
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+unset  CLAUDE_CODE_ENABLE_TELEMETRY
+
 export TMPDIR="$PWD/.tmp"
 mkdir -p "$TMPDIR"
+
+# Local overrides (last — wins over everything above)
+source_env_if_exists .envrc.local


### PR DESCRIPTION
Org-wide .envrc standardization. Self-contained: git identity, beads Hosted DoltDB connection, all secrets from platform secret store (Keychain/pass), telemetry flags, TMPDIR. .envrc.local sourced last for local overrides. No source_up, no cross-directory inheritance. Clone, direnv allow, done.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only changes local `direnv`/developer environment setup, though it may break onboarding if contributors lack the expected Keychain/pass entries or `~/.punt-labs/git-identity.env`.
> 
> **Overview**
> Replaces the repo’s inherited `.envrc` setup (removing `source_up` and unconditional shared env sourcing) with a self-contained, canonical `.envrc`.
> 
> It now inlines Beads Hosted DoltDB connection vars, loads secrets via OS-native stores (macOS Keychain or Linux `pass`), adds telemetry-disabling flags, sets `TMPDIR` to a repo-local `.tmp`, and sources `.envrc.local` last to allow local overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c455ef8d650e2984836e26966a89d608620aeafc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->