### PR TITLE
fix(gitignore): exclude quarry session capture transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ research/spike-voices/
 
 # Vox cached audio
 .vox/*.mp3
+
+# Quarry session-transcript captures (pkit-kcps)
+.punt-labs/quarry/captures/


### PR DESCRIPTION
## Summary

Excludes `.punt-labs/quarry/captures/` (quarry session-transcript captures) from git so
future capture files can't leak into public history.

Security finding pkit-kcps.

## Test plan
- [ ] `git check-ignore -v .punt-labs/quarry/captures/session-0000TESTFAKE.md` matches on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no runtime or application behavior changes.
> 
> **Overview**
> Adds **`.punt-labs/quarry/captures/`** to `.gitignore` so quarry session-transcript captures stay local and are not committed to the repo.
> 
> Addresses security finding **pkit-kcps** (preventing capture files from entering public git history).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5dc417d3b8ef457a4b066656f8a1550cc728be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->