### PR TITLE
fix(gitignore): exclude punt CLI lock artifacts (.*.lock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ research/spike-voices/
 
 # Quarry session-transcript captures (pkit-kcps)
 .punt-labs/quarry/captures/
+
+# The mandated sibling lock every punt CLI takes before mutating a shared
+# host file (tool-enable-disable.md 2.4). Per-machine runtime state, and it
+# persists by design — unlinking a lock file races the next writer. The
+# pattern is broad because the lock's name is the host file's, and tools
+# differ on the suffix — .CLAUDE.md.lock and .CLAUDE.md.punt-import.lock
+# both appear.
+.*.lock


### PR DESCRIPTION
## Summary

Adds `.*.lock` to `.gitignore`. Every punt CLI takes a sibling lock file
(`.{host-file}.lock`, e.g. `.CLAUDE.md.lock`) before mutating a shared host
file (tool-enable-disable.md 2.4). The lock is per-machine runtime state
that persists by design — unlinking it would race the next writer, the
same FileLock semantics already fixed in quarry PR #430. Left untracked-
but-not-ignored, it is one bare `git add -A` away from committing runtime
state to a public repo — the same leak mechanism as pkit-kcps. z-spec
already hit this (v0.17.1 release, cost a full history rewrite).

## Test plan
- [ ] `git check-ignore -q .CLAUDE.md.lock` reports ignored
- [ ] `.gitignore` is the only file changed