### PR TITLE
release: v1.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process — generate professional LaTeX documents for product discovery and decision-making",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-13
+
 ### Added
 
 - `/prfaq:permissions` — grant prfaq's permission rules in the current project, check what is in place, or revoke them
@@ -319,7 +321,8 @@ First tagged release.
 - Plugin cache not clearing on reinstall (stale cache hid new agents)
 - FAQ paragraph indentation inconsistency in `faqpair` environment
 
-[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/punt-labs/prfaq/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/punt-labs/prfaq/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/punt-labs/prfaq/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/punt-labs/prfaq/compare/v1.5.1...v1.5.2

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Fifteen commands form a complete product-thinking workflow:
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/8503f06/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/b163bcc/install.sh | sh
 ```
 
 <details>
@@ -64,7 +64,7 @@ claude plugin install prfaq@punt-labs
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/8503f06/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/b163bcc/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh


### PR DESCRIPTION
Release of the permission-scoping fix merged in #53.

- `.claude-plugin/plugin.json` → 1.7.0 (dev name retained; the prod-name swap happens on the tagged commit)
- CHANGELOG `[Unreleased]` → `[1.7.0] - 2026-08-13`, comparison links updated
- README install SHA pin moved `8503f06` → `b163bcc`, the commit carrying the installer that removes the legacy global rules

Minor, not patch: #53 adds the `/prfaq:permissions` command.

Every user on 1.5.0 through 1.6.1 keeps seeing eight startup warnings per session, in every project, until they re-run the installer — so the pin update is the part that actually reaches them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and version metadata only; no runtime code changes in this diff. The README SHA pin affects which installer users fetch when they follow the documented curl command.
> 
> **Overview**
> **Release packaging for v1.7.0** — the functional work (project-scoped `/prfaq:permissions`, installer no longer writing global rules) ships in the tagged tree; this diff only updates release metadata.
> 
> **Version** in `.claude-plugin/plugin.json` moves **1.6.1 → 1.7.0**. **CHANGELOG** promotes the existing `[Unreleased]` notes into **`[1.7.0] - 2026-08-13`** and refreshes compare links (`[Unreleased]` now tracks `v1.7.0...HEAD`).
> 
> **README** one-liner and “verify before running” install commands now pin **`install.sh` at `b163bcc`** instead of `8503f06`, so users who re-run the installer get the script that strips legacy global permission rules and stops the per-session startup warnings from 1.5.0–1.6.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ca65f4fe50eaa080cae37a70484e06531b5fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->