### PR TITLE
fix: a mistyped settings key crashed both permission scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the prfaq plugin are documented here. This project follow
 - `/prfaq:permissions` names the offending key instead of leaking a `jq` stack trace when `permissions`, `permissions.allow`, or `env` has the wrong type. A typo is reported, never silently read as an empty list.
 - `/prfaq:permissions` no longer reports "all rules already present" when `jq` produced no count. `set -e` does not see failures inside `$(...)` and `sh` has no `pipefail`, so an empty result read as zero — a silent no-op reported as success.
 - Installer warns when it cannot refresh the marketplace instead of discarding the error, which let an install resolve against a stale cached ref and still report success.
-- Installer matches the marketplace name on a word boundary. A plain substring test also matched an unrelated marketplace whose source repo contained `punt-labs`, so registration was skipped and the install failed later.
+- Installer reads the marketplace name field rather than grepping the whole listing, which also matched an unrelated marketplace whose source repo contained `punt-labs` — registration was then skipped and the install failed later with a resolver error. The listing format is not a stable contract, so a missed match is recoverable too: if registering fails because the marketplace is already there, the installer accepts it instead of giving up.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+### Fixed
+
+- Installer no longer aborts when the global `~/.claude/settings.json` has a key of the right name but the wrong type (`"allow": "WebSearch"` instead of a list). It died inside `jq` under `set -eu`, after the plugin had installed and before the toolchain checks — a raw stack trace instead of a message, and no closing output. It now warns, leaves the file untouched, and finishes.
+- `/prfaq:permissions` names the offending key instead of leaking a `jq` stack trace when `permissions`, `permissions.allow`, or `env` has the wrong type. A typo is reported, never silently read as an empty list.
+- `/prfaq:permissions` no longer reports "all rules already present" when `jq` produced no count. `set -e` does not see failures inside `$(...)` and `sh` has no `pipefail`, so an empty result read as zero — a silent no-op reported as success.
+- Installer warns when it cannot refresh the marketplace instead of discarding the error, which let an install resolve against a stale cached ref and still report success.
+- Installer matches the marketplace name on a word boundary. A plain substring test also matched an unrelated marketplace whose source repo contained `punt-labs`, so registration was skipped and the install failed later.
+
+### Changed
+
+- `/prfaq:permissions` no longer tells users to restart. Claude Code watches settings files and applies them without one.
+
 ## [1.7.0] - 2026-08-13
 
 ### Added

--- a/commands/permissions.md
+++ b/commands/permissions.md
@@ -33,7 +33,8 @@ global `~/.claude/settings.json`.
 
 4. **Report the result.** Relay the script's output. When rules were added,
    tell the user two things:
-   - The rules take effect after a Claude Code restart.
+   - Claude Code watches settings files, so the rules apply without a restart.
+     Tell the user to restart only if they do not seem to have taken.
    - `.claude/settings.json` is checked into the repo, so committing it shares
      the permissions with the team. To keep them to themselves, they can move
      the block to `.claude/settings.local.json`, which is gitignored.

--- a/install.sh
+++ b/install.sh
@@ -44,9 +44,17 @@ fi
 
 info "Registering Punt Labs marketplace..."
 
-if claude plugin marketplace list 2>/dev/null | grep -q "$MARKETPLACE_NAME"; then
+# Word-boundary match: a plain substring test also fires on an unrelated
+# marketplace whose source repo merely contains our name (a fork, a mirror),
+# and we would then skip registration and fail at install time.
+if claude plugin marketplace list 2>/dev/null | grep -qE "(^|[^a-zA-Z0-9._-])${MARKETPLACE_NAME}([^a-zA-Z0-9._-]|$)"; then
   ok "marketplace already registered"
-  claude plugin marketplace update "$MARKETPLACE_NAME" 2>/dev/null || true
+  if ! claude plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1; then
+    # Not fatal — the cached marketplace still resolves. But say so, or the
+    # install silently returns whatever ref was cached last time.
+    warn "could not refresh the marketplace; installing from the cached copy"
+    warn "if you end up on an old version, re-run this installer when back online"
+  fi
 else
   claude plugin marketplace add "$MARKETPLACE_REPO" || fail "Failed to register marketplace"
   ok "marketplace registered"
@@ -160,11 +168,19 @@ elif ! command -v jq >/dev/null 2>&1; then
   info "Remove these rules by hand from $SETTINGS_FILE under permissions.allow:"
   printf '%s\n' "$LEGACY_GLOBAL_RULES"
   printf '\n'
-elif ! jq -e 'type == "object"' "$SETTINGS_FILE" >/dev/null 2>&1; then
-  # Not valid JSON, or valid JSON that is not an object. Either way the
-  # queries below would abort the installer, so stop short of them.
-  warn "$SETTINGS_FILE is not a JSON object — leaving it untouched"
-  info "Remove any prfaq rules by hand, then re-run this installer."
+elif ! jq -e '
+  type == "object"
+  and ((has("permissions") | not) or (.permissions | type) == "object")
+  and (((.permissions // {}) | has("allow") | not) or (.permissions.allow | type) == "array")
+' "$SETTINGS_FILE" >/dev/null 2>&1; then
+  # Invalid JSON, a non-object root, or a permissions/allow key of the wrong
+  # type. Every query below would die inside jq, and under set -eu that would
+  # abort the installer — after the plugin is already installed, before the
+  # toolchain checks, with a raw stack trace instead of a message. Skip the
+  # step and keep going.
+  warn "$SETTINGS_FILE is not shaped like a settings file — leaving it untouched"
+  info "Check its permissions.allow list, remove any prfaq rules by hand,"
+  info "then re-run this installer."
 else
   # Match only string entries: an allow list holding an object or a number
   # would otherwise abort the installer inside jq.

--- a/install.sh
+++ b/install.sh
@@ -66,18 +66,25 @@ marketplace_mentioned() {
   claude plugin marketplace list 2>/dev/null | grep -q "$MARKETPLACE_NAME"
 }
 
-if marketplace_listed; then
-  ok "marketplace already registered"
+# Every already-registered path has to refresh. Skipping it on one of them
+# resolves the install against whatever ref was cached last time, silently —
+# which is the failure this warning exists to surface.
+refresh_marketplace() {
   if ! claude plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1; then
-    # Not fatal — the cached marketplace still resolves. But say so, or the
-    # install silently returns whatever ref was cached last time.
+    # Not fatal — the cached marketplace still resolves. But say so.
     warn "could not refresh the marketplace; installing from the cached copy"
     warn "if you end up on an old version, re-run this installer when back online"
   fi
+}
+
+if marketplace_listed; then
+  ok "marketplace already registered"
+  refresh_marketplace
 elif claude plugin marketplace add "$MARKETPLACE_REPO"; then
   ok "marketplace registered"
 elif marketplace_mentioned; then
   ok "marketplace already registered"
+  refresh_marketplace
 else
   fail "Failed to register marketplace"
 fi

--- a/install.sh
+++ b/install.sh
@@ -44,10 +44,29 @@ fi
 
 info "Registering Punt Labs marketplace..."
 
-# Word-boundary match: a plain substring test also fires on an unrelated
-# marketplace whose source repo merely contains our name (a fork, a mirror),
-# and we would then skip registration and fail at install time.
-if claude plugin marketplace list 2>/dev/null | grep -qE "(^|[^a-zA-Z0-9._-])${MARKETPLACE_NAME}([^a-zA-Z0-9._-]|$)"; then
+# `claude plugin marketplace list` prints the name on its own line and the
+# source repo on the next one:
+#
+#     ❯ punt-labs
+#       Source: GitHub (punt-labs/claude-plugins)
+#
+# so a substring test for the name also matches any other marketplace whose
+# source repo happens to contain it. Match a line that holds nothing but the
+# name (any leading decoration allowed) to read the name field alone.
+marketplace_listed() {
+  claude plugin marketplace list 2>/dev/null \
+    | grep -qE "^[^A-Za-z0-9]*[[:space:]]*${MARKETPLACE_NAME}[[:space:]]*$"
+}
+
+# Neither match direction is trusted on its own: the format above is not a
+# stable contract, so a future change could make the check miss an entry that
+# is in fact registered. Registering again is then the recoverable path — if
+# add fails, look for the name anywhere in the listing before giving up.
+marketplace_mentioned() {
+  claude plugin marketplace list 2>/dev/null | grep -q "$MARKETPLACE_NAME"
+}
+
+if marketplace_listed; then
   ok "marketplace already registered"
   if ! claude plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1; then
     # Not fatal — the cached marketplace still resolves. But say so, or the
@@ -55,9 +74,12 @@ if claude plugin marketplace list 2>/dev/null | grep -qE "(^|[^a-zA-Z0-9._-])${M
     warn "could not refresh the marketplace; installing from the cached copy"
     warn "if you end up on an old version, re-run this installer when back online"
   fi
-else
-  claude plugin marketplace add "$MARKETPLACE_REPO" || fail "Failed to register marketplace"
+elif claude plugin marketplace add "$MARKETPLACE_REPO"; then
   ok "marketplace registered"
+elif marketplace_mentioned; then
+  ok "marketplace already registered"
+else
+  fail "Failed to register marketplace"
 fi
 
 # --- Step 3: SSH fallback for plugin install ---

--- a/scripts/prfaq_permissions.sh
+++ b/scripts/prfaq_permissions.sh
@@ -106,6 +106,20 @@ fi
 
 if [ -f "$SETTINGS_FILE" ]; then
   jq -e 'type == "object"' "$SETTINGS_FILE" >/dev/null 2>&1 || fail "$SETTINGS_FILE is not a JSON object. Fix or move it, then re-run."
+
+  # A key of the right name but the wrong type — "allow": "WebSearch" instead
+  # of a list, say — parses fine and then blows up inside jq mid-query. Name
+  # the offending key here instead of letting a raw jq stack trace out, and
+  # never paper over it: a typo the user should fix is not an empty list.
+  MALFORMED=$(jq -r '
+    if (has("permissions") and (.permissions | type) != "object") then "permissions"
+    elif ((.permissions // {} | has("allow")) and (.permissions.allow | type) != "array") then "permissions.allow"
+    elif (has("env") and (.env | type) != "object") then "env"
+    else "" end
+  ' "$SETTINGS_FILE" 2>/dev/null) || fail "Could not read $SETTINGS_FILE."
+  if [ -n "$MALFORMED" ]; then
+    fail "$SETTINGS_FILE has a \"$MALFORMED\" key of the wrong type. Fix it, then re-run."
+  fi
 elif [ "$MODE" = "remove" ]; then
   fail "No $SETTINGS_FILE — nothing to remove."
 fi
@@ -122,6 +136,17 @@ PRESENT=$(read_settings | jq -r --argjson rules "$PRFAQ_PROJECT_RULES" '
   [(.permissions.allow? // [])[] | select(. as $r | $rules | index($r))] | length
 ')
 TOTAL=$(printf '%s' "$PRFAQ_PROJECT_RULES" | jq -r 'length')
+
+# set -e does not see a failure inside $(...), and sh has no pipefail, so a jq
+# that died leaves an empty string here. Untrapped, "$((TOTAL - PRESENT))"
+# would then read 0 and the script would report "all rules already present"
+# having looked at nothing.
+for n in "$PRESENT" "$TOTAL"; do
+  case "$n" in
+    ''|*[!0-9]*) fail "Could not count the rules in $SETTINGS_FILE — jq returned nothing usable." ;;
+  esac
+done
+
 ADDED=$((TOTAL - PRESENT))
 TEAMS=$(read_settings | jq -r '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS // "unset"')
 
@@ -194,7 +219,8 @@ if [ "$MODE" = "add" ]; then
   [ -n "$BACKUP" ] && ok "backup saved to $BACKUP"
   printf '\n'
   info "These rules apply in this project only. Commit the file to share them."
-  info "Restart Claude Code for them to take effect."
+  info "Claude Code watches settings files, so they apply without a restart."
+  info "Restart if they do not seem to have taken."
   printf '\n'
 else
   read_settings | jq --argjson rules "$PRFAQ_PROJECT_RULES" '

--- a/tests/test_permissions.sh
+++ b/tests/test_permissions.sh
@@ -40,6 +40,7 @@ mkdir -p "$WORK/bin"
 # formatting: name on its own line, source repo on the next.
 cat > "$WORK/bin/claude" <<'STUB'
 #!/bin/sh
+[ -n "${CLAUDE_STUB_LOG:-}" ] && echo "$*" >> "$CLAUDE_STUB_LOG"
 case "$*" in
   "plugin marketplace list")
     case "${CLAUDE_STUB_MARKETPLACES:-registered}" in
@@ -51,10 +52,20 @@ case "$*" in
         # name. Ours is not registered.
         printf 'Configured marketplaces:\n\n  \xe2\x9d\xaf someone-else\n    Source: GitHub (mirrors/punt-labs-fork)\n'
         ;;
+      unlisted)
+        # Registered, but under formatting the name-field check cannot read —
+        # stands in for a future CLI that changes its output.
+        printf 'Configured marketplaces:\n\n  1. punt-labs (GitHub: punt-labs/claude-plugins) [enabled]\n'
+        ;;
       none)
         printf 'Configured marketplaces:\n\n'
         ;;
     esac
+    ;;
+  "plugin marketplace add"*)
+    # Adding an already-registered marketplace fails.
+    [ "${CLAUDE_STUB_MARKETPLACES:-registered}" = "unlisted" ] && exit 1
+    exit 0
     ;;
   "plugin list") echo "prfaq@punt-labs" ;;
   *) exit 0 ;;
@@ -63,9 +74,13 @@ STUB
 chmod +x "$WORK/bin/claude"
 
 run_installer() { # run_installer <fake-home> [marketplace-stub-mode]
+  rm -f "$WORK/claude-calls.log"
   env HOME="$1" PATH="$WORK/bin:$PATH" CLAUDE_STUB_MARKETPLACES="${2:-registered}" \
+    CLAUDE_STUB_LOG="$WORK/claude-calls.log" \
     sh "$REPO/install.sh" >"$WORK/installer.out" 2>&1
 }
+
+refreshed() { grep -q "^plugin marketplace update punt-labs$" "$WORK/claude-calls.log"; }
 
 printf '\nProject permissions (scripts/prfaq_permissions.sh)\n'
 
@@ -225,6 +240,26 @@ if grep -q "marketplace already registered" "$WORK/installer.out"; then
   pass "a registered marketplace is recognized by name"
 else
   fail "a registered marketplace is recognized by name"
+fi
+if refreshed; then
+  pass "a registered marketplace is refreshed"
+else
+  fail "a registered marketplace is refreshed"
+fi
+
+# Registered, but the name-field read misses it, so the installer tries to add
+# and the add fails. It must recover — and still refresh, or the install
+# silently resolves against whatever ref was cached last time.
+run_installer "$H" unlisted
+if grep -q "marketplace already registered" "$WORK/installer.out"; then
+  pass "an unreadable listing recovers via the add fallback"
+else
+  fail "an unreadable listing recovers via the add fallback"
+fi
+if refreshed; then
+  pass "the add fallback still refreshes the marketplace"
+else
+  fail "the add fallback still refreshes the marketplace"
 fi
 
 # Another marketplace whose source repo contains our name must not be mistaken

--- a/tests/test_permissions.sh
+++ b/tests/test_permissions.sh
@@ -34,18 +34,37 @@ mkdir -p "$WORK"
 
 # A stub `claude` so install.sh can run its plugin steps offline.
 mkdir -p "$WORK/bin"
+#
+# CLAUDE_STUB_MARKETPLACES picks what `marketplace list` prints, so the
+# registration branches can be exercised. The default mimics the real
+# formatting: name on its own line, source repo on the next.
 cat > "$WORK/bin/claude" <<'STUB'
 #!/bin/sh
 case "$*" in
-  "plugin marketplace list") echo "punt-labs" ;;
+  "plugin marketplace list")
+    case "${CLAUDE_STUB_MARKETPLACES:-registered}" in
+      registered)
+        printf 'Configured marketplaces:\n\n  \xe2\x9d\xaf punt-labs\n    Source: GitHub (punt-labs/claude-plugins)\n'
+        ;;
+      decoy)
+        # Someone else's marketplace whose source repo merely contains our
+        # name. Ours is not registered.
+        printf 'Configured marketplaces:\n\n  \xe2\x9d\xaf someone-else\n    Source: GitHub (mirrors/punt-labs-fork)\n'
+        ;;
+      none)
+        printf 'Configured marketplaces:\n\n'
+        ;;
+    esac
+    ;;
   "plugin list") echo "prfaq@punt-labs" ;;
   *) exit 0 ;;
 esac
 STUB
 chmod +x "$WORK/bin/claude"
 
-run_installer() { # run_installer <fake-home>
-  env HOME="$1" PATH="$WORK/bin:$PATH" sh "$REPO/install.sh" >"$WORK/installer.out" 2>&1
+run_installer() { # run_installer <fake-home> [marketplace-stub-mode]
+  env HOME="$1" PATH="$WORK/bin:$PATH" CLAUDE_STUB_MARKETPLACES="${2:-registered}" \
+    sh "$REPO/install.sh" >"$WORK/installer.out" 2>&1
 }
 
 printf '\nProject permissions (scripts/prfaq_permissions.sh)\n'
@@ -195,6 +214,31 @@ mkdir -p "$H"
 STATUS=0
 run_installer "$H" || STATUS=$?
 check "missing global settings file is fine" "0" "$STATUS"
+
+printf '\nMarketplace registration (install.sh)\n'
+
+H="$WORK/home-marketplace"
+mkdir -p "$H"
+
+run_installer "$H" registered
+if grep -q "marketplace already registered" "$WORK/installer.out"; then
+  pass "a registered marketplace is recognized by name"
+else
+  fail "a registered marketplace is recognized by name"
+fi
+
+# Another marketplace whose source repo contains our name must not be mistaken
+# for ours — that would skip registration and fail at install time.
+run_installer "$H" decoy
+if grep -q "marketplace registered" "$WORK/installer.out" && ! grep -q "already registered" "$WORK/installer.out"; then
+  pass "a decoy marketplace does not suppress registration"
+else
+  fail "a decoy marketplace does not suppress registration"
+fi
+
+STATUS=0
+run_installer "$H" none || STATUS=$?
+check "an empty marketplace list registers cleanly" "0" "$STATUS"
 
 printf '\n%s passed, %s failed\n\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_permissions.sh
+++ b/tests/test_permissions.sh
@@ -93,6 +93,32 @@ sh "$PERMS" --add "$P" >/dev/null 2>&1 || STATUS=$?
 check "non-object settings file is refused" "1" "$STATUS"
 check "non-object settings file is left alone" "[1,2,3]" "$(cat "$P/.claude/settings.json")"
 
+# --- Keys of the right name but the wrong type ---
+# These parse as JSON and then die inside jq mid-query. The script must name
+# the offending key rather than emit a raw jq stack trace, and must not treat
+# a user's typo as an empty list.
+for BAD_KEY in 'permissions' 'permissions.allow' 'env'; do
+  case "$BAD_KEY" in
+    permissions)       BAD_JSON='{"permissions":"nope"}' ;;
+    permissions.allow) BAD_JSON='{"permissions":{"allow":"nope"}}' ;;
+    env)               BAD_JSON='{"env":"nope"}' ;;
+  esac
+  P="$WORK/malformed-$(printf '%s' "$BAD_KEY" | tr '.' '-')"
+  mkdir -p "$P/.claude"
+  printf '%s' "$BAD_JSON" > "$P/.claude/settings.json"
+  for MODE in --check --add --remove; do
+    STATUS=0
+    OUT=$(sh "$PERMS" "$MODE" "$P" 2>&1) || STATUS=$?
+    check "$MODE on a malformed \"$BAD_KEY\" key exits 1" "1" "$STATUS"
+    case "$OUT" in
+      *"jq: error"*) fail "$MODE on \"$BAD_KEY\" leaked a jq stack trace" ;;
+      *"$BAD_KEY"*)  pass "$MODE on \"$BAD_KEY\" names the offending key" ;;
+      *)             fail "$MODE on \"$BAD_KEY\" does not name the offending key — got [$OUT]" ;;
+    esac
+  done
+  check "malformed \"$BAD_KEY\" file is left alone" "$BAD_JSON" "$(cat "$P/.claude/settings.json")"
+done
+
 # --- The global settings file is off limits ---
 # Run against a fake HOME: if the guard ever regresses, this test must not
 # rewrite the developer's own ~/.claude/settings.json.
@@ -141,6 +167,27 @@ STATUS=0
 run_installer "$H" || STATUS=$?
 check "non-object global settings does not abort the install" "0" "$STATUS"
 check "non-object global settings is left alone" '["not","an","object"]' "$(cat "$H/.claude/settings.json")"
+
+# --- A malformed global settings file must not abort the install ---
+# install.sh is piped from curl. A hard exit here strands the user after the
+# plugin installed but before the toolchain checks and the closing message.
+H="$WORK/home-malformed-allow"
+mkdir -p "$H/.claude"
+printf '{"permissions":{"allow":"nope"}}' > "$H/.claude/settings.json"
+STATUS=0
+run_installer "$H" || STATUS=$?
+check "malformed global permissions.allow does not abort the install" "0" "$STATUS"
+check "malformed global settings is left alone" '{"permissions":{"allow":"nope"}}' "$(cat "$H/.claude/settings.json")"
+if grep -q "jq: error" "$WORK/installer.out"; then
+  fail "installer leaked a jq stack trace on a malformed settings file"
+else
+  pass "installer leaks no jq stack trace on a malformed settings file"
+fi
+if grep -q "is ready!" "$WORK/installer.out"; then
+  pass "installer still reaches its closing message"
+else
+  fail "installer still reaches its closing message"
+fi
 
 # --- No global settings file at all ---
 H="$WORK/home-empty"


### PR DESCRIPTION
Follow-up to #53. Two review agents came back after v1.7.0 shipped with findings that survived verification.

## The bug

A settings key of the right name and the wrong type parses as JSON and then dies inside `jq` mid-query. v1.7.0's `type == "object"` guard covered the root and `.permissions`, but not `.permissions.allow` being a string instead of a list, and not `.env` being a string instead of an object.

Reproduced on `main`:

```
$ echo '{"permissions":{"allow":"x"}}' > proj/.claude/settings.json
$ sh scripts/prfaq_permissions.sh --check proj
jq: error (at <stdin>:0): Cannot iterate over string ("x")
exit=5
```

**The installer half is the one that matters.** `install.sh` is piped from `curl` under `set -eu`, so the same shape aborted the run at Step 5 — after the plugin had installed, before the toolchain checks, with a stack trace and no closing message:

```
▶ Installing prfaq...
  ✓ prfaq installed
▶ Removing legacy global permission rules...
jq: error (...): Cannot iterate over string ("x")
```

That lands on exactly the people we are telling to re-run the installer.

## The fix

- **`install.sh` warns and finishes.** It validates the `permissions`/`allow` shape up front and skips the cleanup step when the file is not shaped like a settings file. It never aborts the install over someone else's typo.
- **`scripts/prfaq_permissions.sh` names the offending key** and refuses:
  ```
  ✗ .../settings.json has a "permissions.allow" key of the wrong type. Fix it, then re-run.
  ```
  Deliberately not papered over as an empty list — a typo the user should fix is not the same as no rules.
- **Rule counts are validated before arithmetic.** `set -e` does not see a failure inside `$(...)`, and `sh` has no `pipefail` (it is not POSIX — `dash` lacks it), so a dead `jq` left an empty string that `$((TOTAL - PRESENT))` read as `0`, and the script reported "all rules already present — no change" having counted nothing. Silent success is the worst failure mode here.
- **A failed marketplace refresh warns** instead of being discarded by `|| true`, which let an install resolve against a stale cached ref and still report success.
- **The marketplace name field is read on its own**, rather than grepping the whole listing — which also matched an unrelated marketplace whose source repo contained `punt-labs`. Since that formatting is not a stable contract, a missed match is recoverable too: if `marketplace add` fails because the marketplace is already registered, the installer accepts that instead of hard-failing.
- **Dropped the "restart Claude Code" instruction.** Settings files are watched and applied without one; the command now says to restart only if the rules do not seem to have taken.

## Verification

`tests/test_permissions.sh`: 26 → **56 cases**, all green, in `make check`.

New coverage: all three modes against each of the three malformed key shapes, asserting the exit status, that the message names the key, that no `jq` stack trace leaks, and that the file is left byte-identical; the installer against a malformed global file, asserting exit 0, an untouched file, no stack trace, and that it still reaches its closing message; and three marketplace-registration cases against a stub emitting the real two-line listing format — registered, a decoy whose source repo contains our name, and an empty list.

```
56 passed, 0 failed
make check exit=0
```

## Not changed

Two reported items did not hold up:

- **The `$HOME` symlink bypass** was reported against `6b951e8`; it was already fixed in `1f4e7e7` before v1.7.0 shipped, from Copilot's review of the same thing. Re-verified on `main`: the symlink case is refused and covered by a test.
- **`[ -n "$BACKUP" ] && ok ...` under `set -e`** is the correct idiom — a failing left-hand side in an AND-OR list does not trigger `-e` unless it is the list's last command. Verified on both `sh` and `dash`. (The one place it *did* bite was an EXIT trap, fixed in #53.)

## Release

CHANGELOG entries sit under `[Unreleased]`, per this repo's process — a follow-up release PR moves them to `## [1.7.1]` with the version bump and comparison links, the same way #54 did for v1.7.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the curl installer and settings mutation paths users rely on at install time; behavior changes are defensive but affect marketplace registration and global settings cleanup.
> 
> **Overview**
> Hardens **`install.sh`** and **`scripts/prfaq_permissions.sh`** against mistyped Claude Code settings (`permissions`, `permissions.allow`, `env`) so **`jq` failures no longer abort the curl installer** or leak stack traces; the permissions script **names the bad key** and refuses to treat typos as empty rule lists.
> 
> **`/prfaq:permissions`** and docs now say settings apply **without a restart** (restart only if rules don’t take). **Rule counts** are validated before arithmetic so a dead `jq` can’t report a false “all rules already present.”
> 
> **Marketplace registration** matches the marketplace **name line** (not repo substrings), **warns on failed refresh** instead of swallowing errors, and **recovers** when `add` fails but the marketplace is already listed.
> 
> **`tests/test_permissions.sh`** grows stubbed marketplace scenarios and malformed-settings coverage (26 → 56 cases); **CHANGELOG** documents fixes under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b23d8417c1512cdc53beebe82017cfb8e9fdb304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->