### PR TITLE
release: v1.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process — generate professional LaTeX documents for product discovery and decision-making",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-13
+
 ### Fixed
 
 - Installer no longer aborts when the global `~/.claude/settings.json` has a key of the right name but the wrong type (`"allow": "WebSearch"` instead of a list). It died inside `jq` under `set -eu`, after the plugin had installed and before the toolchain checks — a raw stack trace instead of a message, and no closing output. It now warns, leaves the file untouched, and finishes.
@@ -333,7 +335,8 @@ First tagged release.
 - Plugin cache not clearing on reinstall (stale cache hid new agents)
 - FAQ paragraph indentation inconsistency in `faqpair` environment
 
-[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/punt-labs/prfaq/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/punt-labs/prfaq/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/punt-labs/prfaq/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/punt-labs/prfaq/compare/v1.5.2...v1.6.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Fifteen commands form a complete product-thinking workflow:
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/b163bcc/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/5d3bffa/install.sh | sh
 ```
 
 <details>
@@ -64,7 +64,7 @@ claude plugin install prfaq@punt-labs
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/b163bcc/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/5d3bffa/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh


### PR DESCRIPTION
Release of the robustness fixes merged in #55.

- `.claude-plugin/plugin.json` → 1.7.1 (dev name retained; the prod-name swap happens on the tagged commit)
- CHANGELOG `[Unreleased]` → `[1.7.1] - 2026-08-13`, comparison links updated
- README install SHA pin moved `b163bcc` → `5d3bffa`

Patch, not minor: #55 is all fixes, no new surface.

The pin is the point again. v1.7.0's installer aborted mid-run — after the plugin installed, before the toolchain checks — for anyone whose global `~/.claude/settings.json` had a `permissions.allow` of the wrong type. That is the same population being told to re-run the installer to clear the legacy rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and version metadata only; no application code changes in this diff.
> 
> **Overview**
> **Release v1.7.1** — packaging only for the installer and `/prfaq:permissions` robustness work already merged (#55); this PR does not change runtime behavior beyond the version bump.
> 
> Bumps **plugin version** in `.claude-plugin/plugin.json` from `1.7.0` to `1.7.1`, promotes the **CHANGELOG** `[Unreleased]` notes into **`[1.7.1] - 2026-08-13`**, and refreshes compare links so `[Unreleased]` tracks `v1.7.1...HEAD`.
> 
> Updates the **README** one-liner and “verify before running” install URLs to pin `install.sh` at commit **`5d3bffa`** instead of **`b163bcc`**, so new installs pull the fixed installer (notably for users re-running after v1.7.0’s mid-install abort on malformed global `~/.claude/settings.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0917aba2bbb641a231570a8a293061ce5d6f8194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->