### PR TITLE
fix: drop dead Write() deny rules from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -136,9 +136,7 @@
       "Bash(tftp:*)",
       "Bash(wget:*)",
       "Edit(.env)",
-      "Edit(.envrc)",
-      "Write(.env)",
-      "Write(.envrc)"
+      "Edit(.envrc)"
     ]
   }
 }


### PR DESCRIPTION
Closes prfaq-l1l.

`.claude/settings.json` carried two rules that match nothing:

```json
"Write(.env)",
"Write(.envrc)"
```

Claude Code matches path-scoped permission rules under `Edit(path)` only — that one form covers Write, Edit, and NotebookEdit — so each of these printed a startup warning in this repo, every session. The warning fires on deny rules just as it does on allow rules.

**No loss of enforcement.** `Edit(.env)` and `Edit(.envrc)` are in the same deny list and do the actual work. Verified after the change:

```
$ grep -c '"Write(' .claude/settings.json
0
deny has Edit(.env): True
deny has Edit(.envrc): True
allow count: 112   deny count: 19
```

This is the same defect prfaq shipped to users in v1.5.0–v1.6.1 and fixed in v1.7.0 — the repo's own settings still carried it.

Root cause is upstream in punt-kit (`pkit-lv32`): `src/punt_kit/init.py:601,603` seeds this pair into every scaffolded repo, and `standards/permissions.md` documents `Write(path)` as valid syntax. Ten repos plus `punt-labs/team` carry them; nine sibling beads track the rest.

`make check` passes — both `.tex` files compile, 59 permission tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup; `.env` / `.envrc` protection is unchanged via the remaining `Edit` deny rules.
> 
> **Overview**
> Removes **`Write(.env)`** and **`Write(.envrc)`** from the deny list in **`.claude/settings.json`**.
> 
> Claude Code only honors path-scoped rules as **`Edit(path)`**, which already blocks writes/edits to those files—so the **`Write(...)`** entries were invalid, triggered startup warnings, and added no enforcement beyond the existing **`Edit(.env)`** / **`Edit(.envrc)`** denies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948f30b16c807e263d87ddcaf7fb86034c2cc83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->