### PR TITLE
release: v1.7.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process — generate professional LaTeX documents for product discovery and decision-making",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-08-19
+
 ### Fixed
 
 - Installing the plugin no longer requires a GitHub SSH key. The repo carried a `.punt-labs/ethos` git submodule pointing at `git@github.com:punt-labs/team.git`, and Claude Code clones plugins with submodules — so the install aborted with `Failed to clone '.punt-labs/ethos' a second time, aborting` for anyone without a key configured. The submodule is removed; agents resolve identities from the global `~/.punt-labs/ethos/` at runtime.
@@ -344,7 +346,8 @@ First tagged release.
 - Plugin cache not clearing on reinstall (stale cache hid new agents)
 - FAQ paragraph indentation inconsistency in `faqpair` environment
 
-[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.7.2...HEAD
+[1.7.2]: https://github.com/punt-labs/prfaq/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/punt-labs/prfaq/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/punt-labs/prfaq/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/punt-labs/prfaq/compare/v1.6.0...v1.6.1


### PR DESCRIPTION
## Summary

Cut version 1.7.2 with the submodule-removal fix that landed in #59.

- `.claude-plugin/plugin.json`: 1.7.1 → 1.7.2 (dev name retained)
- `CHANGELOG.md`: `[Unreleased]` → `[1.7.2] - 2026-08-19`; compare links updated

After merge: tag with the name-swap dance, create GitHub Release, and bump the marketplace catalog to point at `v1.7.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or install script changes in this diff—only version and documentation for an already-landed release.
> 
> **Overview**
> **Release v1.7.2** — metadata-only cut for fixes already merged (e.g. #59).
> 
> `.claude-plugin/plugin.json` version goes **1.7.1 → 1.7.2** (dev plugin name unchanged). `CHANGELOG.md` moves notes from `[Unreleased]` into **`[1.7.2] - 2026-08-19`**: plugin install no longer needs GitHub SSH (`.punt-labs/ethos` submodule removed; identities from `~/.punt-labs/ethos/`), Linux permission tests fixed (`printf` escape in stub `claude`), and ~1.1 MB of vendored org-identity files no longer shipped at install. Compare links at the bottom of the changelog are updated for the new tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5806339ee1e5d98e258071bfda9692d1a86d03c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->