### PR TITLE
docs(README): refresh install URL SHA pin to current install.sh (27def5c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Fifteen commands form a complete product-thinking workflow:
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/5d3bffa/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/27def5c/install.sh | sh
 ```
 
 <details>
@@ -64,7 +64,7 @@ claude plugin install prfaq@punt-labs
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/5d3bffa/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/27def5c/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh


### PR DESCRIPTION
The README install one-liners pinned a stale install.sh commit (5d3bffa). Re-verified against origin/main via `git log -1 --format=%h origin/main -- install.sh`: the current install.sh commit is **27def5c**. Updates both raw.githubusercontent.com pins so the live install link matches what is released now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only SHA pin updates with no runtime or security logic changes.
> 
> **Overview**
> Updates the **Installation** curl one-liner and the **Verify before running** download URL so both point at `install.sh` at commit **`27def5c`** instead of the stale **`5d3bffa`** pin.
> 
> No install behavior or script content changes—only the `raw.githubusercontent.com` commit refs in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d11e04b338d328157a671b1d5e6a24c55b2603f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->