### PR TITLE
chore(envrc): sync canonical .envrc (OPENROUTER_API_KEY)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -39,6 +39,7 @@ case "$(uname -s)" in
     _puntlabs_export_if_set ELEVENLABS_API_KEY           "$(security find-generic-password -s 'elevenlabs-api-key' -w 2>/dev/null)"
     _puntlabs_export_if_set RESEND_API_KEY               "$(security find-generic-password -s 'RESEND_API_KEY' -w 2>/dev/null)"
     _puntlabs_export_if_set CONTEXT7_API_KEY             "$(security find-generic-password -s 'CONTEXT7_API_KEY' -w 2>/dev/null)"
+    _puntlabs_export_if_set OPENROUTER_API_KEY           "$(security find-generic-password -s 'OPENROUTER_API_KEY' -w 2>/dev/null)"
     ;;
   Linux)
     _puntlabs_export_if_set BEADS_DOLT_PASSWORD          "$(pass show beads/dolt-password 2>/dev/null)"
@@ -48,6 +49,7 @@ case "$(uname -s)" in
     _puntlabs_export_if_set ELEVENLABS_API_KEY           "$(pass show elevenlabs/api-key 2>/dev/null)"
     _puntlabs_export_if_set RESEND_API_KEY               "$(pass show resend/api-key 2>/dev/null)"
     _puntlabs_export_if_set CONTEXT7_API_KEY             "$(pass show context7/api-key 2>/dev/null)"
+    _puntlabs_export_if_set OPENROUTER_API_KEY           "$(pass show openrouter/api-key 2>/dev/null)"
     ;;
   *)
     # Unknown platform — leave secrets to the shell rc file or explicit export.


### PR DESCRIPTION
## Summary
- Adds the missing `OPENROUTER_API_KEY` macOS Keychain / Linux `pass` lookups to `.envrc`, syncing with `.bin/envrc-canonical.template` in the workspace meta-repo.

## Test plan
- [x] `.envrc` diff limited to the two `_puntlabs_export_if_set OPENROUTER_API_KEY` lines
- docs-only/config-only change — no runnable code touched

docs-only — Phase 3 verification N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only envrc change; no application or auth logic. Missing store entries still skip export.
> 
> **Overview**
> Adds `OPENROUTER_API_KEY` to direnv secret loading, matching the other API keys.
> 
> On macOS it reads Keychain service `OPENROUTER_API_KEY`; on Linux it uses `pass show openrouter/api-key`. Export still happens only when the lookup is non-empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a31d483ea8d6c0fb46875acf7d9c18d811ec7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->