### PR TITLE
docs: add install-all.sh to the release SHA-pin checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,9 @@ Branch protection is active, so every step that touches main goes through a PR.
     - `prfaq/README.md` — install.sh SHA pin
     - `public-website/src/data/projects.json` — version + install SHA
     - `punt-labs/.github profile/README.md` — only if it has a prfaq-specific pin
+    - `punt-labs/.github/install-all.sh` — the pinned `claude-plugins` commit
+      in its "Marketplace" step must resolve to a `marketplace.json` whose
+      prfaq entry matches this release's `source.ref`/`version` (see step 10)
 
 12. **Verify** the tag has the prod name:
     ```bash


### PR DESCRIPTION
## Summary
- Closes a gap found while fixing a live bug: `punt-labs/.github/install-all.sh` pinned `claude-plugins` to a commit two releases stale (`v1.6.1`, full-repo `github` source) while prfaq had already shipped `v1.7.3` with the git-subdir fix — because this checklist never listed that pin.
- Adds `punt-labs/.github/install-all.sh` to step 11's downstream SHA-pin list, alongside the existing README/website/profile pins.

## Test plan
- Docs-only change — `npx markdownlint-cli2 "CLAUDE.md"` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the release process; no runtime, auth, or packaging behavior is modified.
> 
> **Overview**
> **Release checklist (step 11)** now includes **`punt-labs/.github/install-all.sh`** as a downstream pin to update after a prfaq release, alongside the existing README, website, and profile README pins.
> 
> The new bullet spells out that the script’s pinned **`claude-plugins`** commit in its Marketplace step must point at a **`marketplace.json`** whose prfaq **`source.ref`** and **`version`** match the release just shipped in step 10—closing a gap that let install-all lag behind prfaq (e.g. stale v1.6.1 pin while prfaq was on v1.7.3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed0c599683d3791e25c2f2e9a74a3beb1f092da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->