### PR TITLE
fix: meeting pre-meeting scan defaults to prose quality, not substance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+### Changed
+- **`/prfaq:meeting` and `/prfaq:meeting-hive`'s hot-spot scan now defaults to product substance, not prose quality.** The pre-meeting scan's criteria were entirely a documentation-quality checklist (citation gaps, vague words, thin FAQs, hedging mismatches) — running a real meeting against them produced an agenda of copy-editing issues with no bearing on competition, customers, the business model, or scope. The four risk-lens questions (feasibility, value/customer reality, strategic fit/viability, ambition) now come first, with a guardrail requiring at least half the agenda to be substance rather than documentation issues.
+- **Meeting debate narratives and `/prfaq:meeting-listen` dialogue must ground every line in a document specific** (a quoted phrase, a real number, a named competitor or customer segment) instead of abstract metaphor standing in for the reasoning, and must never have a persona reference the meeting's own sequence ("third hot spot in a row," "unlike the previous item"). Cross-hot-spot patterns belong in the summary's Notes section, not spoken in a persona's voice.
+
+### Fixed
+- **`/prfaq:meeting-listen` called a retired vox tool.** `mcp__plugin_vox_mic__who` no longer exists; voice-roster detection now uses the no-arg `mcp__plugin_vox_mic__voice` call, which returns the same shape (`all` renamed to `available`).
+
 ## [1.7.3] - 2026-08-20
 
 ### Changed

--- a/meetings/meeting-hive-summary-2026-08-29.md
+++ b/meetings/meeting-hive-summary-2026-08-29.md
@@ -1,0 +1,50 @@
+# PR/FAQ Review Meeting Summary
+**Date:** 2026-08-29
+**Document:** prfaq.tex
+**Mode:** Hive (autonomous consensus, Agent Teams)
+**Scope:** Full meeting (6 hot spots)
+
+## Decisions
+
+| # | Hot Spot | Door | Decision | Resolution | Winning Argument | Dissent |
+|---|----------|------|----------|------------|-------------------|---------|
+| 1 | TAM paragraph stacks incommensurable metrics (Lovable/Replit user counts, Bolt ARR, Codex WAU) as if directly comparable | Two-way | REVISE | CONSENSUS | Unanimous: stacking implies false comparability; split into distinct, honestly-labeled signals without dropping any citation | None |
+| 2 | Press-release customer quote (invented persona) carries no signal distinguishing it from the real, anonymized PM evidence two pages later | Two-way | REVISE | CONSENSUS | Unanimous: a reader unfamiliar with Working Backwards convention can't tell invented from real; add one contrast line opening the customer-evidence FAQ, leave the press-release quote itself untouched | None |
+| 3 | Value risk mitigation rests entirely on two not-yet-executed dated actions, structurally identical to the mitigation that already failed and caused this risk's re-rating | Two-way | REVISE | CONSENSUS | Unanimous, Wei/Alex sharpest: a future-dated plan with no interim checkpoint reproduces the exact silent-slippage failure mode that got Value risk re-rated High; add an early tripwire before 2026-09-30, name an owner, make escalation trigger on silence not just a negative result | None |
+| 4 | Viability risk row omits the real ~5-month release gap (2026-03-20 to 2026-08-13), describing only a hypothetical future maintenance cadence | Two-way | REVISE | CONSENSUS | Unanimous: the row whose job is to assess maintainer sustainability is the one place the most relevant data point is missing; acknowledge the gap in the row itself, state confidence about recurrence or flag it as unresolved | None |
+| 5 | Competitive-landscape differentiation claim ("no one else combines the framework + multi-agent debate") rests on a single, unverified research pass | Two-way | REVISE | CONSENSUS | Unanimous: negative claims need more coverage than positive ones; hedge the wording to match the evidence ("no plugin surfaced in this search...") rather than requiring new hands-on evaluation | None |
+| 6 | "Next step" FAQ's dated actions have no named owner and (for action 2) no built-in negative-result clause | Two-way | REVISE | CONSENSUS | Unanimous, explicit non-duplicate ruling: hot spot 3's fix patches the Value risk row's *citation*; this fixes the *source* FAQ the plan is actually executed from — name an owner, extend action 1's existing "silence is itself the finding" framing to action 2, and have the risk row reference the FAQ rather than re-deriving its own copy | None |
+
+## Revision Queue (for /prfaq:feedback)
+
+### Directive 1: Fix the TAM trajectory-upside metric stacking
+Split the "A wave of non-programmers is building software..." sentence (TAM FAQ) into signals labeled by what they actually measure — e.g., a scale sentence (Lovable/Replit user counts) and a separate commercial-pull/behavior sentence (Bolt ARR, Codex WAU, YC cohort composition) — rather than one additive list implying equivalent units. Keep every existing citation; this is a framing fix, not a sourcing change.
+
+### Directive 2: Distinguish illustrative from real customer evidence
+Add one contrast sentence at the top of the customer-evidence FAQ (fifth paragraph, the first-hand adoption signal) establishing that this evidence is real and first-hand, in contrast to the illustrative press-release quote. Do not add any qualifier to the press-release quote itself or its attribution — leave that section exactly as-is; the fix lives entirely in the FAQ.
+
+### Directive 3: Add an interim tripwire to the Value risk mitigation
+In the Value risk row's mitigation clause, add: a named owner for the diagnostic actions, an interim checkpoint before 2026-09-30 (e.g., "if no diagnostic conversation has started by 2026-09-08, escalate immediately"), and make the escalation clause trigger on silence/non-execution, not only on a completed-but-inconclusive result.
+
+### Directive 4: Acknowledge the release gap in the Viability risk row
+Add one sentence to the Viability risk row naming the actual ~5-month gap (2026-03-20 to 2026-08-13) before stating the forward-looking 4-8 hrs/week estimate at 500+ stars. State the document's actual confidence about recurrence, or flag it plainly as unresolved if unknown.
+
+### Directive 5: Hedge the competitive differentiation claim
+In the competitors FAQ's "Market update, Q3 2026" paragraph, soften "It does not implement... nor a multi-agent debate feature comparable to..." to name the claim's actual evidentiary basis — e.g., "no plugin surfaced in this single research pass implements..." — without weakening the underlying differentiation argument.
+
+### Directive 6: Name an owner and extend the negative-result clause in the "next step" FAQ
+In the "next step to validate your vision" FAQ, name the owner for both dated actions (author, for a solo-maintainer project). Extend action (1)'s existing "if this doesn't happen, that itself is the finding" framing to action (2) as well. Update the Value risk row's mitigation clause (Directive 3) to reference this FAQ's checkpoint/owner rather than re-deriving its own separate copy, so the two don't drift out of sync.
+
+## Deferred Items
+None — all six hot spots reached full consensus with no persistent splits.
+
+## Research Completed
+None — no researcher agent was invoked during this meeting. Hot spot 5's own finding (that the competitive claim needs more research or a hedge) is itself queued as Directive 5, not resolved via a research pass during the meeting.
+
+## Notes
+
+**A structural pattern, not six isolated findings.** Every hot spot converged on the same root cause, independently observed and named by multiple personas across the session: a confident or forward-looking statement (a plan, a projection, a differentiation claim) presented without being reconciled against a contradicting or weaker fact sitting elsewhere in the same document. Alex named this explicitly after hot spot 4 (hot spots 2-4 sharing the shape) and again after hot spot 6 (identifying it as the fourth instance, alongside the original failed "ship publicly, recruit 10 users" commitment this document already diagnosed in its own "What have we learned since launch?" FAQ). This is worth treating as a standing authoring check for future revisions of this document, not just six one-off fixes: **when adding a plan, a projection, or a confident claim, check whether a contradicting or weaker fact already exists elsewhere in the document, and reconcile them in the same edit.**
+
+No hot spot reached a one-way door or required a Round 2 rebuttal — all six resolved on unanimous or majority Round 1 positions. This is consistent with the document having already been through two rounds of peer review and substantial revision earlier this session; the remaining issues were evidence-framing and internal-consistency gaps, not open architectural or scope questions.
+
+Directives 3 and 6 are related but distinct — apply them together in the same `/prfaq:feedback` pass so the risk-row summary and the source FAQ stay consistent with each other.

--- a/plugin/commands/meeting-hive.md
+++ b/plugin/commands/meeting-hive.md
@@ -39,7 +39,7 @@ Then restart Claude Code. Do not proceed without it — use `/prfaq:meeting` for
 
 2. **Read the meeting guide.** Load `${CLAUDE_PLUGIN_ROOT}/skills/prfaq/references/meeting-guide.md` for persona details and stage calibration. The hive meeting uses the same cast, reference guides, and hot spot ranking as the regular meeting.
 
-3. **Run the pre-meeting scan.** Read the full `.tex` document. Extract `\prfaqstage{value}` to calibrate expectations. Identify 5-8 hot spots using the same criteria as the regular meeting (unsupported claims, vague language, thin evidence, risk rating mismatches, confidence/hedging gaps). Rank each as Critical, Warning, or Suggestion — calibrated to the document's stage.
+3. **Run the pre-meeting scan.** Read the full `.tex` document. Extract `\prfaqstage{value}` to calibrate expectations. Identify 5-8 hot spots using the same criteria as the regular meeting — the four risk-lens questions (feasibility, value/customer reality, strategic fit/viability, ambition) come first; documentation and evidence issues (unsupported claims, vague language, thin evidence, hedging gaps) are valid but must be at most half the agenda. See the meeting guide's Phase 0 guardrail. Rank each as Critical, Warning, or Suggestion — calibrated to the document's stage.
 
 4. **Classify each hot spot as a one-way or two-way door.** For each hot spot, determine whether the decision it implies is reversible (two-way door: positioning, scope, framing) or irreversible (one-way door: architecture, data model, public commitments). Mark each in the agenda.
 
@@ -99,7 +99,7 @@ Then restart Claude Code. Do not proceed without it — use `/prfaq:meeting` for
 
    Mark the hot spot task complete via TaskUpdate after resolution.
 
-8. **Synthesize the debate.** For each hot spot, write a brief narrative (3-5 sentences) that shows which argument won and why. Name the winner and the loser. Do not soften — "Wei's scalability concern overruled Dana's push to ship" is better than "the group balanced speed and caution." Follow the synthesis voice guidelines from the meeting guide.
+8. **Synthesize the debate.** For each hot spot, write a brief narrative (3-5 sentences) that shows which argument won and why. Name the winner and the loser. Do not soften — "Wei's scalability concern overruled Dana's push to ship" is better than "the group balanced speed and caution." Ground every sentence in a specific from the document (a quoted phrase, a real number, a named competitor or customer segment) — never in an abstract metaphor standing in for the reasoning, and never in a reference to another hot spot's position in this meeting ("third hot spot in a row," "unlike the previous item"). A cross-hot-spot pattern, if one emerges, belongs in the summary's Notes section, not spoken in a persona's voice. Follow the synthesis voice guidelines from the meeting guide.
 
 9. **Shut down the team.** Send a shutdown request to each teammate using SendMessage with `type: "shutdown_request"`. Wait for acknowledgment, then clean up the team.
 

--- a/plugin/commands/meeting-listen.md
+++ b/plugin/commands/meeting-listen.md
@@ -40,7 +40,7 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
    - `voice_fallback` — value `default` means use the provider's default voice
    - `voice_vibe` — expressive tags (ElevenLabs only)
 
-   **In voiced mode**, detect the active provider. Call `mcp__plugin_vox_mic__who` and read the `provider` field from the response. Select the voice field for each persona:
+   **In voiced mode**, detect the active provider. Call `mcp__plugin_vox_mic__voice` with no argument and read the `provider` field from the response (`mcp__plugin_vox_mic__who` is retired; the no-arg `voice` call returns the same shape). Select the voice field for each persona:
 
    | Provider | Voice Field | Vibe Tags |
    |----------|-------------|-----------|
@@ -54,7 +54,7 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
 
 4. **Validate ElevenLabs voices (voiced mode, ElevenLabs provider only).** The `voice_elevenlabs` values may be community voices that require the user to add them to their ElevenLabs voice library. Before voicing any hot spots:
 
-   - Read the `all` array from the `mcp__plugin_vox_mic__who` response (this lists all voices in the user's library)
+   - Read the `available` array from the `mcp__plugin_vox_mic__voice` (no-arg) response (this lists all voices in the user's library)
    - Check whether each persona's `voice_elevenlabs` value appears in the list
    - For any missing voices, build a fallback map using built-in ElevenLabs voices:
 
@@ -114,6 +114,8 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
    - Keep each line 1-3 sentences. Spoken dialogue is shorter than written analysis.
    - The conversation should feel like overhearing a real debate, not a script reading
    - For KEEP-tone decisions, the defending persona should sound confident; for REVISE-tone, the challenger should sound vindicated
+   - **Ground every line in a specific from the document** — a quoted phrase, a real number, a named competitor or customer segment — never an abstract turn of phrase standing in for the reasoning ("same disease, different organ" tells a listener nothing; naming the actual number or claim does). A listener hearing only this hot spot's segment, with no other context, must be able to say what specific thing is wrong and what the fix is.
+   - **Never have a persona reference this meeting's own sequence** — no "third hot spot in a row," "unlike the previous item," "this isn't a duplicate of hot spot N." Each hot spot must stand alone. If the summary's Notes section records a cross-hot-spot pattern, leave it there — do not voice it as something a persona says mid-debate.
 
    **c. Output each line.** Always print each dialogue line with a speaker label prefix for the transcript, regardless of mode:
 
@@ -129,11 +131,12 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
      **Narrator segment** (first in array):
      - `text`: A scene-setter that orients the listener. Synthesize from the summary row:
        - Name the hot spot and which part of the document it concerns
+       - **State the actual claim, number, or quoted text under debate** — not just the section name. "The team debated whether per-seat pricing alienates small teams" tells a listener nothing about what the document actually says; "the document prices at $12 per seat with no volume discount, and the team debated whether that alienates 5-person teams" does. If the summary row doesn't spell out the specific text, pull it from the source `.tex` document.
        - For hive summaries: mention the door and the core tension from the resolution
        - For interactive summaries: mention the severity and the gist of the rationale
        - End with the decision outcome so the listener knows the frame
-       - Example: "Hot spot 3: Pricing model, in the customer FAQ section. The team debated whether per-seat pricing alienates small teams. They decided to revise."
-     - Keep it to 2-3 sentences — enough context to follow the debate, not a full recap
+       - Example: "Hot spot 3 concerns the Getting Started FAQ, which prices the product at \$12 per seat with no volume discount. The team debated whether that alienates 5-person teams who'd pay \$60/month for a tool they use twice a week. They decided to revise."
+     - Keep it to 2-4 sentences — enough to state the actual claim and the tension, not a full recap. Prioritize naming the specific over staying at the low end of the sentence count.
      - Omit `voice` — uses the session default, naturally distinguishing the narrator from persona voices
      - Omit `vibe_tags`
 

--- a/plugin/commands/meeting-listen.md
+++ b/plugin/commands/meeting-listen.md
@@ -136,7 +136,7 @@ Check whether `mcp__plugin_vox_mic__unmute` is available. Set a session flag:
        - For interactive summaries: mention the severity and the gist of the rationale
        - End with the decision outcome so the listener knows the frame
        - Example: "Hot spot 3 concerns the Getting Started FAQ, which prices the product at \$12 per seat with no volume discount. The team debated whether that alienates 5-person teams who'd pay \$60/month for a tool they use twice a week. They decided to revise."
-     - Keep it to 2-4 sentences — enough to state the actual claim and the tension, not a full recap. Prioritize naming the specific over staying at the low end of the sentence count.
+     - Keep it to 2-4 sentences — enough to state the actual claim and the tension, not a full recap. Prioritize naming the specific over staying at the low end of the sentence count. (This narrator segment is the one exception to the 1-3 sentence dialogue-line guideline above, which applies to the persona lines that follow, not this scene-setter.)
      - Omit `voice` — uses the session default, naturally distinguishing the narrator from persona voices
      - Omit `vibe_tags`
 

--- a/plugin/commands/meeting.md
+++ b/plugin/commands/meeting.md
@@ -14,7 +14,7 @@ Run an interactive review meeting where four personas — a principal engineer, 
 
 2. **Read the meeting guide.** Load `${CLAUDE_PLUGIN_ROOT}/skills/prfaq/references/meeting-guide.md` for the full meeting flow, synthesis guidelines, and persona details.
 
-3. **Run the pre-meeting scan.** Read the full `.tex` document. Extract `\prfaqstage{value}` to calibrate expectations (see Stage Calibration in the meeting guide). Identify 5-8 hot spots: sections with unsupported claims, vague language, thin evidence, risk rating mismatches, or gaps between press release confidence and FAQ hedging. Rank each as Critical, Warning, or Suggestion — calibrated to the document's stage.
+3. **Run the pre-meeting scan.** Read the full `.tex` document. Extract `\prfaqstage{value}` to calibrate expectations (see Stage Calibration in the meeting guide). Identify 5-8 hot spots using the four risk-lens questions first (feasibility, value/customer reality, strategic fit/viability, ambition — see Phase 0 in the meeting guide) — documentation issues (unsupported claims, vague language, thin evidence, hedging gaps) are valid but must be at most half the agenda. Rank each as Critical, Warning, or Suggestion — calibrated to the document's stage.
 
 4. **Present the agenda.** Show the user the hot spots ranked by severity and offer scope options via AskUserQuestion:
    - Full meeting (all items)
@@ -29,7 +29,7 @@ Run an interactive review meeting where four personas — a principal engineer, 
       - `subagent_type: "prfaq:meeting-customer"` (Priya)
       - `subagent_type: "prfaq:meeting-executive"` (Alex)
       - `subagent_type: "prfaq:meeting-builder"` (Dana)
-   c. Synthesize their responses into a dramatic debate narrative (not concatenation)
+   c. Synthesize their responses into a dramatic debate narrative (not concatenation). Ground every sentence in a specific from the document — a quoted phrase, a real number, a named competitor or customer segment — never an abstract metaphor, and never a reference to another hot spot's position in this meeting. See "Ground Every Line in Specifics" and "Never Reference the Meeting's Own Structure" in the meeting guide.
    d. Present the decision via AskUserQuestion: Revise / Keep as-is / Research / Defer
    e. Show cascade consequences (which other sections are affected)
 

--- a/plugin/skills/prfaq/references/meeting-guide.md
+++ b/plugin/skills/prfaq/references/meeting-guide.md
@@ -35,7 +35,7 @@ Identify **hot spots** — sections where the document is weakest. These are jud
 Documentation and evidence issues are still valid hot spots, but they are the minority, not the default:
 1. `[CITATION NEEDED]` markers
 2. Claims without `\cite{}` references
-3. Risk ratings rated Low with weak supporting evidence
+3. Risk ratings marked Low with weak supporting evidence
 4. Vague language: "significant", "many", "rapidly growing"
 5. FAQ answers that are thin (1-2 sentences) on questions that deserve depth
 6. The gap between press release confidence and FAQ hedging

--- a/plugin/skills/prfaq/references/meeting-guide.md
+++ b/plugin/skills/prfaq/references/meeting-guide.md
@@ -25,14 +25,22 @@ The key tension: Wei + Alex pull toward caution. Dana pulls toward ambition. Pri
 
 Identify **hot spots** — sections where the document is weakest. These are judgment calls with real tradeoffs, not formatting issues.
 
-How to find hot spots:
-1. Read the full `.tex` document
-2. Check for `[CITATION NEEDED]` markers — each is a hot spot
-3. Look for claims without `\cite{}` references
-4. Check risk ratings — any risk rated Low with weak supporting evidence
-5. Look for vague language: "significant", "many", "rapidly growing"
-6. Check FAQ answers that are thin (1-2 sentences) on questions that deserve depth
-7. Look for the gap between press release confidence and FAQ hedging
+**Hot spots must be substance, not prose quality.** A hot spot exists because a real business or product judgment is shaky — not because a sentence is unsourced or a word is vague. Ask the four risk-lens questions directly against the document's actual claims:
+
+- **Feasibility (Wei's lens):** Does the architecture or build plan actually hold up at the scale or timeline implied? Is there an operational or maintenance risk the document waves off as solved? Does a claimed technical result (e.g., "no infrastructure to build") hide a real ongoing cost?
+- **Value / customer reality (Priya's lens):** Does the target customer segment actually cohere, or is the document serving two audiences with incompatible needs? Would a real person in that segment behave the way the document assumes? Is customer demand asserted where it should be evidenced?
+- **Strategic fit / viability (Alex's lens):** Is the business model or monetization stance defensible given the document's own data? Is the claimed competitive moat actually differentiated, or just asserted? Does the document duck an opportunity-cost question — why this, and not something else?
+- **Ambition (Dana's lens):** Is the scope too conservative or too narrow given the opportunity the document itself describes? Is the document defending a comfortable middle position instead of picking a side?
+
+Documentation and evidence issues are still valid hot spots, but they are the minority, not the default:
+1. `[CITATION NEEDED]` markers
+2. Claims without `\cite{}` references
+3. Risk ratings rated Low with weak supporting evidence
+4. Vague language: "significant", "many", "rapidly growing"
+5. FAQ answers that are thin (1-2 sentences) on questions that deserve depth
+6. The gap between press release confidence and FAQ hedging
+
+**Guardrail:** at least half of the 5-8 hot spots identified must come from the four risk-lens questions above, not the documentation-quality list. If a scan turns up mostly citation gaps, hedging mismatches, or wording fixes, that is a sign the scan defaulted to copy-editing — stop and re-ask the four risk-lens questions directly against the document's claims about customers, competitors, business model, and scope before finalizing the agenda.
 
 Rank each hot spot:
 - **Critical** — undermines the core argument (must address)
@@ -193,6 +201,16 @@ The debate should have genuine moments of insight. Look for:
 3. **The concession** — a persona admits the other has a point (rare and powerful)
 4. **The escalation** — a concern gets worse when you look deeper
 
+### Ground Every Line in Specifics
+
+Every sentence of the debate narrative — and any later spoken reconstruction of it — must reference an actual specific from the document: a quoted phrase, a real number, a named competitor, a named customer segment. An abstract metaphor standing in for the reasoning ("same disease, different organ") tells the reader nothing on its own; the concrete version ("the Viability row omits the five-month gap the cost-structure FAQ already admits to") tells them everything. If a line would still make sense with the specific nouns swapped out for a different hot spot, it is too abstract — rewrite it.
+
+**Test:** could someone who has read only this hot spot's narrative, with no other context, explain in their own words what specific thing is wrong and what the fix is? If not, it is not grounded enough yet.
+
+### Never Reference the Meeting's Own Structure
+
+Do not have a persona comment on the meeting's own sequence or shape — "third hot spot in a row," "unlike the previous item," "this is the Nth time tonight," "this isn't a duplicate of hot spot 3." Each hot spot's narrative must stand alone; a reader or listener should never need to remember an earlier hot spot to follow this one. Cross-hot-spot patterns (the same failure mode recurring across multiple hot spots, say) are real findings worth recording — put them in the summary's **Notes** section, in prose, written for a reader. Never have a persona say it aloud mid-debate as if commenting on the meeting itself.
+
 ### What NOT to Do
 
 - Don't have personas agree too easily ("I agree with Wei that...")
@@ -201,6 +219,8 @@ The debate should have genuine moments of insight. Look for:
 - Don't summarize what each persona said — dramatize the conflict
 - Don't invent disagreements that don't exist — if they genuinely agree, say so briefly and move on
 - Don't make Dana a cheerleader — she has standards too
+- Don't let a persona narrate the meeting's own structure instead of the document's content (see above)
+- Don't reach for an abstract turn of phrase in place of the actual concrete reasoning (see above)
 
 ## Early Exit
 
@@ -285,7 +305,7 @@ The door type changes how votes are weighted — not equally, but by relevance:
 
 ### Synthesis in Hive Mode
 
-The debate narrative is shorter than in regular meetings (3-5 sentences per hot spot, not a full dramatic scene). The goal is to communicate the key tension and the resolution, not to dramatize the conflict. Save the user's reading time — they'll read N summaries, not participate in N debates.
+The debate narrative is shorter than in regular meetings (3-5 sentences per hot spot, not a full dramatic scene). The goal is to communicate the key tension and the resolution, not to dramatize the conflict. Save the user's reading time — they'll read N summaries, not participate in N debates. The same grounding rules apply at this shorter length: every sentence still needs to name a specific from the document, and no sentence references another hot spot's position in the sequence.
 
 For split decisions, present both sides' strongest single argument and ask the user to decide.
 


### PR DESCRIPTION
## Summary

Ran a real `/prfaq:meeting-hive` against this repo's own `prfaq.tex` (dogfooding), then `/prfaq:meeting-listen` on the result. Found two independent problems in the skill files, not just one bad run:

1. **`meeting-guide.md`'s Phase 0 hot-spot criteria were entirely a documentation-quality checklist** — citation gaps, vague words, thin FAQs, hedging mismatches. Running the scan against them produced six hot spots with no bearing on competition, customers, the business model, or scope — every "debate" was really about labeling a number correctly or naming an owner. The four risk-lens questions (feasibility, value/customer reality, strategic fit/viability, ambition) now come first, with a guardrail requiring at least half the agenda to be substance rather than documentation issues.
2. **The debate narrative and `/prfaq:meeting-listen`'s spoken dialogue had no rule against personas narrating the meeting's own structure** ("third hot spot in a row", "this isn't a duplicate of hot spot 3") instead of the document's actual content — incoherent to a listener who'd have to track the whole session's meta-structure to follow any single hot spot. Added an explicit grounding rule (every line must name a document specific — a quote, a number, a named competitor/segment) and a ban on meeting-self-reference; cross-hot-spot patterns now belong in the summary's Notes section, never spoken in a persona's voice.

Also fixes `/prfaq:meeting-listen` calling the retired `mcp__plugin_vox_mic__who` tool — voice-roster detection now uses the no-arg `voice()` call, which returns the same response shape (`all` renamed to `available`).

Includes `meetings/meeting-hive-summary-2026-08-29.md`, the actual meeting this session ran, as the historical record of what prompted the fix.

## Test plan
- [x] `npx markdownlint-cli2` on all five touched files — 0 errors
- [x] `make check` — pdflatex compile + permission-script tests, 59/59 passed
- Docs/skill-content change — no runnable code touched beyond markdown prompt files; verification is that the content reads correctly and the retired-tool fix matches the current `mcp__plugin_vox_mic__voice` tool's actual response shape (confirmed via its own docstring during this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are markdown skill/command prompts plus a meeting artifact; the only behavioral fix is aligning TTS integration with the current vox `voice` API.
> 
> **Overview**
> **PR/FAQ meeting flows** (`/prfaq:meeting`, `/prfaq:meeting-hive`, and the shared `meeting-guide`) now prioritize **product substance** in the pre-meeting scan: the four risk-lens questions (feasibility, value/customer, strategic fit/viability, ambition) come first, with a guardrail that **at least half** of 5–8 hot spots must not be documentation-quality issues (citations, vague wording, thin FAQs). That replaces a scan that effectively behaved like a copy-editing checklist.
> 
> **Debate synthesis and `/prfaq:meeting-listen` playback** gain explicit rules: every narrative or spoken line must anchor in a **document specific** (quote, number, named competitor/segment), personas must not reference **meeting order** (“third hot spot in a row”), and cross-hot-spot patterns belong in summary **Notes** only. Hive synthesis and listen **narrator** segments must state the actual claim under debate, not just the section name.
> 
> **`/prfaq:meeting-listen`** stops calling retired `mcp__plugin_vox_mic__who`; provider and voice roster use no-arg `mcp__plugin_vox_mic__voice` (`available` instead of `all`).
> 
> **CHANGELOG** records the above; **`meetings/meeting-hive-summary-2026-08-29.md`** is added as the dogfooding session that motivated the skill updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e0374d6c46865fc0c47ab4cc1c72e1b653616b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->