### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,7 +369,9 @@ First tagged release.
 - Plugin cache not clearing on reinstall (stale cache hid new agents)
 - FAQ paragraph indentation inconsistency in `faqpair` environment
 
-[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.7.2...HEAD
+[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/punt-labs/prfaq/compare/v1.7.3...v1.8.0
+[1.7.3]: https://github.com/punt-labs/prfaq/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/punt-labs/prfaq/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/punt-labs/prfaq/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/punt-labs/prfaq/compare/v1.6.1...v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-29
+
 ### Added
 - **`/prfaq:meeting` and `/prfaq:meeting-hive` open and close with an exec assessment.** A standalone Alex (Skeptical Executive) read frames the stakes before the agenda and delivers a closing verdict — plus a concrete next-step/reconvene proposal — after every hot spot is decided, matching typical review-meeting structure instead of jumping straight into itemized debate and stopping cold after the last item. Both reads are organized around the three questions product development lives or dies on: is this a problem worth solving, do we have a strong and differentiated solution, and should we build this now given competing priorities. Persisted in the summary's new `## Overall Assessment` section. `/prfaq:meeting-listen` voices both, and its closing now recaps concrete follow-up items from the revision queue and any deferred decisions, plus the agreement to reconvene when the closing read names one (grounded in the actual proposal — never a generic "let's touch base").
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prfaq",
   "description": "Amazon Working Backwards PR/FAQ process \u2014 generate professional LaTeX documents for product discovery and decision-making",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version bump and changelog/link updates only; no runtime code changes in the diff.
> 
> **Overview**
> **Release v1.8.0** — bumps `plugin/.claude-plugin/plugin.json` from **1.7.3** to **1.8.0** and records the shipped work in **CHANGELOG.md** (dated 2026-08-29), with compare links updated for `[Unreleased]`, `[1.8.0]`, and `[1.7.3]`.
> 
> The new changelog section documents **meeting workflow** changes already in the plugin: `/prfaq:meeting` and `/prfaq:meeting-hive` gain Alex opening/closing exec assessments persisted under `## Overall Assessment`; hot-spot scanning prioritizes product substance (four risk lenses) over documentation-quality issues; debate and `/prfaq:meeting-listen` dialogue must cite document specifics and avoid meta meeting references; and meeting-listen switches voice detection from retired `mcp__plugin_vox_mic__who` to no-arg `mcp__plugin_vox_mic__voice` (`available` vs `all`).
> 
> This PR does not modify commands or agents—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf98f61cc4678037d7b1530aab93d9c820d41777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->