### PR TITLE
fix: restore-dev-plugin.sh checked out a stale historical ref instead of flipping the name field

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "prfaq",
+  "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process \u2014 generate professional LaTeX documents for product discovery and decision-making",
   "version": "1.8.0",
   "author": {

--- a/scripts/release-plugin.sh
+++ b/scripts/release-plugin.sh
@@ -29,9 +29,9 @@ echo "Swapping plugin name: ${current_name} → ${prod_name}"
 PLUGIN_PATH="${REPO_ROOT}/${PLUGIN_JSON}" PROD_NAME="$prod_name" python3 -c "
 import json, pathlib, os
 p = pathlib.Path(os.environ['PLUGIN_PATH'])
-d = json.loads(p.read_text())
+d = json.loads(p.read_text(encoding='utf-8'))
 d['name'] = os.environ['PROD_NAME']
-p.write_text(json.dumps(d, indent=2) + '\n')
+p.write_text(json.dumps(d, indent=2) + '\n', encoding='utf-8')
 "
 
 git -C "$REPO_ROOT" add "$PLUGIN_JSON"

--- a/scripts/restore-dev-plugin.sh
+++ b/scripts/restore-dev-plugin.sh
@@ -43,9 +43,9 @@ echo "Restoring plugin name: ${current_name} → ${dev_name}"
 PLUGIN_PATH="${REPO_ROOT}/${PLUGIN_JSON}" DEV_NAME="$dev_name" python3 -c "
 import json, pathlib, os
 p = pathlib.Path(os.environ['PLUGIN_PATH'])
-d = json.loads(p.read_text())
+d = json.loads(p.read_text(encoding='utf-8'))
 d['name'] = os.environ['DEV_NAME']
-p.write_text(json.dumps(d, indent=2) + '\n')
+p.write_text(json.dumps(d, indent=2) + '\n', encoding='utf-8')
 "
 
 git -C "$REPO_ROOT" add "$PLUGIN_JSON"

--- a/scripts/restore-dev-plugin.sh
+++ b/scripts/restore-dev-plugin.sh
@@ -15,6 +15,16 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # plugin/ so a git-subdir marketplace install fetches only that subtree.
 PLUGIN_JSON="plugin/.claude-plugin/plugin.json"
 
+# The old script took an optional restore ref and validated it. This one
+# doesn't restore from a ref at all, so a stale --resume=<sha>-style
+# invocation must fail loudly rather than silently do something else.
+if [[ $# -gt 0 ]]; then
+  echo "Error: this script takes no arguments (got: $*)." >&2
+  echo "       It rewrites the name field in the current working tree —" >&2
+  echo "       it no longer restores from a historical ref. Drop the argument." >&2
+  exit 1
+fi
+
 # Require a clean working tree so we don't overwrite local changes.
 if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
   echo "Error: working tree is not clean. Commit or stash changes before restoring." >&2

--- a/scripts/restore-dev-plugin.sh
+++ b/scripts/restore-dev-plugin.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Restore dev plugin state on main after a release tag.
+# Restore dev plugin state on main after a release tag. Mirrors
+# release-plugin.sh's swap exactly, in reverse: a targeted rewrite of the
+# `name` field, nothing else. It does not check out plugin.json from a
+# historical ref — main can go an arbitrary number of commits between
+# releases without ever holding the dev name (e.g. if a prior release
+# skipped this script), and a ref-based restore has no correct commit to
+# point at in that case. Operating on the current working-tree content
+# instead makes the restore correct regardless of how main got here.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Repo-relative, because it is handed to git. The shippable surface lives under
@@ -21,36 +28,15 @@ if [[ "$current_name" == *-dev ]]; then
   exit 1
 fi
 
-# Optional argument: commit/tag to restore from (defaults to HEAD~1).
-RESTORE_REF="${1:-HEAD~1}"
-if ! git -C "$REPO_ROOT" rev-parse "$RESTORE_REF" >/dev/null 2>&1; then
-  echo "Error: invalid ref to restore from: $RESTORE_REF" >&2
-  exit 1
-fi
+dev_name="${current_name}-dev"
+echo "Restoring plugin name: ${current_name} → ${dev_name}"
+PLUGIN_PATH="${REPO_ROOT}/${PLUGIN_JSON}" DEV_NAME="$dev_name" python3 -c "
+import json, pathlib, os
+p = pathlib.Path(os.environ['PLUGIN_PATH'])
+d = json.loads(p.read_text())
+d['name'] = os.environ['DEV_NAME']
+p.write_text(json.dumps(d, indent=2) + '\n')
+"
 
-COMMANDS_DIR="plugin/commands"
-
-# git checkout aborts if *any* pathspec matches nothing, so probe every one it
-# will be given — not just the first. A ref from before the plugin/ move
-# carries the surface at the repo root and matches neither, and an odd
-# intermediate ref could carry one without the other; either way git says only
-# "did not match any file(s) known to git". Name the ref and the paths instead.
-missing=()
-for path in "$PLUGIN_JSON" "$COMMANDS_DIR"; do
-  if ! git -C "$REPO_ROOT" ls-tree --name-only "$RESTORE_REF" -- "$path" | grep -q .; then
-    missing+=("$path")
-  fi
-done
-
-if [[ ${#missing[@]} -gt 0 ]]; then
-  echo "Error: $RESTORE_REF does not contain: ${missing[*]}" >&2
-  echo "       A ref from before the plugin/ move has the surface at the repo" >&2
-  echo "       root instead. Restore from a later ref, or check out" >&2
-  echo "       .claude-plugin/plugin.json and commands/ from it by hand." >&2
-  exit 1
-fi
-
-# Restore plugin.json and commands from the specified commit
-git -C "$REPO_ROOT" checkout "$RESTORE_REF" -- "$PLUGIN_JSON" "$COMMANDS_DIR"
-git -C "$REPO_ROOT" add "$PLUGIN_JSON" "$COMMANDS_DIR"
+git -C "$REPO_ROOT" add "$PLUGIN_JSON"
 git -C "$REPO_ROOT" commit --no-verify -m "chore: restore dev plugin state"


### PR DESCRIPTION
## Summary

- `scripts/restore-dev-plugin.sh` defaulted to restoring `plugin.json` (and the entire `plugin/commands/` directory!) by `git checkout`-ing them from `HEAD~1`, assuming that ref legitimately carried the dev-suffixed plugin name.
- That assumption silently broke: the v1.7.3 release (#63) merged the prod-name swap commit straight to `main` and never ran the restore step, so `main` has been stuck on the prod name (`"prfaq"`, not `"prfaq-dev"`) for the entire v1.7.3 → v1.8.0 development window. `HEAD~1` was prod-named too — restoring from it was a no-op on the name field.
- Worse: the only commits that ever carried the dev name predate a directory restructuring (`27def5c`/`7644962`). Restoring `plugin/commands/` from either would have silently reverted months of command file changes — discovered while diagnosing this during the v1.8.0 release, before it could do that damage.
- Rewrote the script to mirror `release-plugin.sh`'s existing, safe approach exactly, in reverse: a targeted Python JSON edit of only the `name` field, operating on the current working tree instead of any historical ref. No longer touches `commands/` at all (confirmed via full-history search: no `*-dev.md` file has ever existed in this repo, so nothing is lost).
- Also actually ran the fixed script (commit `f989a4e`) to restore `main`'s `plugin.json` to `"prfaq-dev"` — a clean one-line diff, version untouched.
- Local review (`code-reviewer`) found one real gap: the new script silently ignored any arguments instead of failing loudly, when the old interface took and validated a restore-ref argument. Added an explicit guard that rejects any argument with a clear message, since stale muscle memory (`--resume=<sha>`-style invocations) should fail loudly, not silently do something different.

## Why

Discovered mid-release (v1.8.0, via `/punt:auto release`): the `punt` CLI's post-release phase ran this script as part of restoring dev state after tagging, and it silently failed to actually flip the name. Root-caused by reading the script and reconstructing exactly why `HEAD~1` couldn't possibly have the dev name in this repo's current history.

## Test plan

- [x] `shellcheck` clean
- [x] `make check` (LaTeX compile gate + permission tests) passes
- [x] Ran the fixed script directly against a clean tree — confirmed exact one-line `name` field change, nothing else
- [x] Verified in a throwaway worktree/direct invocation that passing arguments now fails loudly with a clear message instead of silently ignoring them
- [x] Full-history search (`git log --all --diff-filter=A --name-only -- '*-dev.md'`, full `git ls-tree -r` sweep) confirms no `*-dev.md` command file convention has ever existed in this repo — dropping `commands/` restoration loses no real capability
- [x] Confirmed release tags (`v1.7.3`, `v1.8.0`) both still resolve to the prod name — this fix only affects `main`'s working state, not what ships

Docs-only/tooling change — no runnable plugin behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/restore shell tooling and `plugin.json` dev naming on `main` only; tagged release artifacts and plugin runtime behavior are unchanged.
> 
> **Overview**
> **Fixes post-release dev restore** so `main` reliably gets the `-dev` plugin name again after a release, without touching `plugin/commands/` or any historical git ref.
> 
> `restore-dev-plugin.sh` no longer `git checkout`s `plugin.json` and `plugin/commands/` from `HEAD~1` (or another ref). That path failed when `main` had stayed on the prod name and could have reverted months of command changes from old refs. It now mirrors `release-plugin.sh` in reverse: a Python rewrite of only the `name` field in the current working tree, then commit. Passing any arguments is rejected with a clear error (the old optional restore-ref interface is gone).
> 
> Also sets **`plugin.json` on `main` back to `prfaq-dev`** (one-line name change) and uses **explicit UTF-8** when reading/writing JSON in both release and restore scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55da71e7bead7519ac9428b2c295b5efc841663c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->