### PR TITLE
docs: add docs/WORKFLOW.md, tighten branch-discipline loophole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 I am a principal engineer. Every change I make leaves the codebase in a better state than I found it. I do not excuse new problems by pointing at existing ones. I do not defer quality to a future ticket. I do not create tech debt.
 
+## Mandatory Reading
+
+@docs/WORKFLOW.md
+
+`WORKFLOW.md` is the three-loop development process (backlog → PR → delegation) that governs every change to this repo, no matter how small it looks. Read it before writing or editing anything — it is the enforcement mechanism for the branch/bead/review discipline described below.
+
 ## No "Pre-existing" Excuse
 
 There is no such thing as a "pre-existing" issue. If you see a problem — in code you wrote, code a reviewer flagged, or code you happen to be reading — you fix it. Do not classify issues as "pre-existing" to justify ignoring them. Do not suggest that something is "outside the scope of this change." If it is broken and you can see it, it is your problem now.
@@ -19,7 +25,7 @@ There is no such thing as a "pre-existing" issue. If you see a problem — in co
 
 ### Branch Discipline
 
-Feature work goes on feature branches. Small fixes (typos, compilation fixes, single-file doc edits) can go directly to main.
+**Nothing lands on `main` except through a merged PR — no exceptions, no bypass-rights shortcuts.** Every change, including a one-line typo fix, goes through a branch. What varies by size is only the branch's *name and lifetime*, never whether it exists:
 
 ```bash
 git checkout -b feat/short-description main
@@ -34,20 +40,18 @@ git checkout -b feat/short-description main
 | `refactor/` | Restructuring without behavior change |
 | `docs/` | Documentation, CHANGELOG, README |
 
-**When to branch:**
+**Long-lived feature branch** (multi-session work):
 - New skill commands (`/prfaq:import`, `/prfaq:meeting`)
 - Template environment changes that affect generated output
 - Multi-file changes that touch skill prompts, reference guides, and templates together
 - Any work that might take multiple sessions
 
-**When a feature branch is not needed** (PR directly from a short-lived branch):
+**Short-lived branch** (same prefixes, deleted right after merge — still a branch, still a PR):
 - Single-file fixes (compilation, typos, formatting)
 - CHANGELOG updates
 - Dogfood document edits that don't change the template
 
-Branch protection is active — all changes require a PR, but these don't need
-a long-lived feature branch. Releases have their own process (see
-[Release Process](#release-process) below).
+**The exemption above is about how trivial one change is, never about how many files it touches.** A prose-quality pass across several documents is not "a single-file doc edit" repeated — it is exactly the kind of multi-file work that needs a bead, a branch, and local review, even when every individual edit is mechanical. See `docs/WORKFLOW.md` for the full loop (this is Loop 2's Branch step) and the incident that prompted this rewrite (`prfaq-6wz`).
 
 ### Micro-Commits
 
@@ -91,12 +95,16 @@ Match the workflow to the bead's scope. The deciding factor is **design ambiguit
 | **T1: Forge** | `/feature-forge` | Epics, cross-cutting work, competing design approaches | Beads with dependencies |
 | **T2: Feature Dev** | `/feature-dev` | Features, multi-file, clear goal but needs exploration | Beads + TodoWrite (internal) |
 | **T3: Direct** | Plan mode or manual | Tasks, bugs, obvious implementation path | Beads |
+| **T4: Trivial** | Manual | Single-character/single-line fix, one file, no judgment call | No bead — commit message is the record |
 
 **Decision flow:**
 
 1. Is there design ambiguity needing multi-perspective input? → **T1: Forge**
 2. Does it touch multiple files and benefit from codebase exploration? → **T2: Feature Dev**
-3. Otherwise → **T3: Direct** (plan mode if >3 files, manual if fewer)
+3. Is it a genuinely single-file, single-line, no-judgment-call fix? → **T4: Trivial**
+4. Otherwise → **T3: Direct** (plan mode if >3 files, manual if fewer)
+
+**T4 skips the bead. It never skips the branch.** Every tier, including T4, still goes through Loop 2 in `docs/WORKFLOW.md` (branch → verify → local review → PR → merge). "No bead" is not "no process."
 
 **Bead type mapping:**
 
@@ -324,6 +332,8 @@ Before creating a PR, verify:
 - [ ] **Cached plugin copy updated** if skill or reference guide files changed
 
 ### Pull Request and Code Review Workflow
+
+**Local review happens before any of this, not after.** See `docs/WORKFLOW.md` § Loop 2 for which review agents apply to what you changed — run them to zero findings before pushing. GitHub review cycles below catch what local review can't (CI, a second set of eyes); they are not a substitute for it.
 
 Do **not** merge immediately after creating a PR. Expect **2–6 review cycles** before merging. The full flow is:
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -16,9 +16,15 @@ except through a merged PR.** See `prfaq-6wz`.
 
 *What to work on, and in what order.*
 
-1. `bd ready --limit=99` — see everything unblocked.
-2. Pick a bead, or create one (`bd create "<title>" --description "..."`) if
-   the work isn't tracked yet. Skip this only for genuinely trivial,
+1. `bd ready --label-any repo:prfaq` — see everything unblocked. Beads is a
+   single shared central DB across all punt-labs repos; `bd ready` does not
+   auto-scope to this repo in bd 1.0.4 the way `bd list` does (see
+   `.beads/config.yaml` and `.beads/README.md`), so the bare form can surface
+   other repos' work. `bd list` alone is auto-scoped and fine for a quick
+   look; use the `--label-any` form for anything you're about to act on.
+2. Pick a bead, or create one (`bd create "<title>"`, optionally with
+   `--description "..."` for extra context) if the work isn't tracked yet.
+   Skip this only for genuinely trivial,
    single-file, single-session fixes (see Workflow Tiers, T4 below) — even
    those still go through Loop 2.
 3. `bd update <id> --status=in_progress` to claim it.
@@ -88,6 +94,15 @@ seconds. Pick agents by what changed:
 | Skill prompts, agent personas, reference guides | `prfaq:peer-reviewer` (content/methodology review, not code review) |
 | LaTeX templates or the dogfood document's structure | `prfaq:peer-reviewer`, then confirm `make check` still compiles cleanly |
 | Meeting summaries, or any prose subject to the banlist | the prose-lint hook already gates this live; additionally re-run `python3 plugin/scripts/prose_lint.py --config plugin/banlist.conf --profile business <file>` by hand for anything edited outside the `Write`/`Edit` tools (a direct Bash file write bypasses the hook — see `plugin/hooks/prose_lint_hook.py` for why bulk cleanups sometimes need this path) |
+
+The `feature-dev:*` and `pr-review-toolkit:*` names are Claude Code
+sub-agents shipped by the `feature-dev` and `pr-review-toolkit` plugins —
+not something defined inside this repo, so they're only invokable in a
+session where those plugins are installed. `prfaq:peer-reviewer` ships with
+*this* repo's own plugin and is always available. If the `feature-dev`/
+`pr-review-toolkit` plugins aren't installed in your session, substitute a
+manual read-through of the diff against `CLAUDE.md`'s Standards and this
+doc's Loop 2, rather than skipping the step.
 
 Fix every finding or document why it doesn't apply (no "pre-existing," no
 "outside scope" — see `CLAUDE.md` § No "Pre-existing" Excuse). Re-run until

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,120 @@
+# Development Workflow
+
+Three nested loops. Read this before touching any file in the repo — it is
+`@`-imported from `CLAUDE.md` so it loads at session start.
+
+This doc exists because a 2026-08-30 session edited `prfaq.tex` and eight
+files under `meetings/` directly on `main` — no bead, no branch, no local
+review, nothing committed for hours of work. The cause was a single
+ambiguous sentence in `CLAUDE.md`'s old Branch Discipline section ("Small
+fixes... can go directly to main") read as license to skip the PR loop
+entirely for anything that felt mechanical. It never did license that, and
+after this rewrite it cannot be misread that way: **nothing lands on `main`
+except through a merged PR.** See `prfaq-6wz`.
+
+## Loop 1: Backlog
+
+*What to work on, and in what order.*
+
+1. `bd ready --limit=99` — see everything unblocked.
+2. Pick a bead, or create one (`bd create "<title>" --description "..."`) if
+   the work isn't tracked yet. Skip this only for genuinely trivial,
+   single-file, single-session fixes (see Workflow Tiers, T4 below) — even
+   those still go through Loop 2.
+3. `bd update <id> --status=in_progress` to claim it.
+4. Pick a tier (`CLAUDE.md` § Workflow Tiers) — T1 Forge, T2 Feature Dev, T3
+   Direct, or T4 (see below). The tier decides which tool drives Loop 2, not
+   whether Loop 2 runs.
+
+**T4: Trivial, no bead.** A single-character typo fix, a broken link, a
+version-string bump nobody could disagree with. No design ambiguity, no
+judgment call, one file, one line. Still goes through Loop 2 (branch, PR) —
+T4 only means skip the bead, not skip the branch.
+
+**The exemption is about triviality of the single change, never about
+count.** "Eight files, each edit mechanical" is not T4 — it is exactly the
+kind of work Loop 2 exists to catch, because a mechanical edit repeated
+eight times is eight chances to get one of them wrong, and nobody reviewed
+any of them before this session found out the hard way (`prfaq-6wz`). If
+you are touching more than one file, or a content-quality pass across
+several documents, claim a bead and branch — full stop.
+
+## Loop 2: PR
+
+*One rollback-coherent merge.* This is the loop that failed on 2026-08-30.
+Every step below is mandatory; none is exempt for "small" work — only the
+bead in Loop 1 is optional (T4), never the branch, never local review.
+
+```text
+claim (Loop 1)
+  → branch            git checkout -b <prefix>/<short-description> main
+  → implement          write the change
+  → verify              make check  (must pass before every commit)
+  → document            CHANGELOG.md, README.md, DESIGN.md as applicable
+  → local review        run the applicable review agents (see below) to zero findings
+  → ship                commit → push → PR → Copilot review → cycle to clean → merge
+  → close               bd close <id>, delete branch, pull main
+```
+
+**Branch.** `git checkout -b <prefix>/<short-description> main` — always,
+even for a single-file fix. Prefixes: `feat/`, `fix/`, `refactor/`, `docs/`
+(see `CLAUDE.md` § Branch Discipline for the full table). "Short-lived" and
+"no long-lived feature branch needed" describe how long the branch lives
+and what it's named, never whether one exists. Branch protection is
+already configured to require a PR for everything; this loop is what makes
+that configuration actually bite in practice instead of getting routed
+around by `claude-puntlabs` bypass rights. Bypass rights exist for CI
+emergencies, not for convenience — see the org-wide `punt-labs/CLAUDE.md`
+§ Claude Agento (loaded via Claude Code's ancestor-directory walk from the
+`punt-labs/` workspace meta-repo, not a file inside this repo).
+
+**Implement & Verify.** `make check` (compiles every `.tex` in `TEX_DIRS`,
+runs the permission tests, runs the prose-lint test suite) must pass before
+every commit, not just before the PR. A commit that fails `make check` is a
+broken commit.
+
+**Document.** `CHANGELOG.md` for user-facing change (skip for internal-only
+edits per the existing rule), `README.md` if install/usage changed,
+`DESIGN.md` ADR for an architectural or process decision with rejected
+alternatives.
+
+**Local Review.** The step this session skipped entirely. Run before
+pushing, not after — GitHub review cycles are slow; local review is
+seconds. Pick agents by what changed:
+
+| Touched | Run |
+|---|---|
+| Python (`plugin/scripts/*.py`, `plugin/hooks/*.py`) | `feature-dev:code-reviewer` + `pr-review-toolkit:silent-failure-hunter` |
+| Skill prompts, agent personas, reference guides | `prfaq:peer-reviewer` (content/methodology review, not code review) |
+| LaTeX templates or the dogfood document's structure | `prfaq:peer-reviewer`, then confirm `make check` still compiles cleanly |
+| Meeting summaries, or any prose subject to the banlist | the prose-lint hook already gates this live; additionally re-run `python3 plugin/scripts/prose_lint.py --config plugin/banlist.conf --profile business <file>` by hand for anything edited outside the `Write`/`Edit` tools (a direct Bash file write bypasses the hook — see `plugin/hooks/prose_lint_hook.py` for why bulk cleanups sometimes need this path) |
+
+Fix every finding or document why it doesn't apply (no "pre-existing," no
+"outside scope" — see `CLAUDE.md` § No "Pre-existing" Excuse). Re-run until
+clean. Only then push.
+
+**Ship.** Push, open the PR (`mcp__github__create_pull_request`), request
+Copilot review once, then cycle per `CLAUDE.md` § Pull Request and Code
+Review Workflow until a review round is uneventful. Merge via
+`mcp__github__merge_pull_request`.
+
+**Close.** `bd close <id>` (if a bead existed), delete the branch, pull
+main, and — this is also mandatory, not optional — actually push before the
+session ends (see `CLAUDE.md` § Session Close Protocol).
+
+## Loop 3: Delegation
+
+*One worker/evaluator dispatch*, nested inside Loop 2's implement step when
+the work matches a row in `CLAUDE.md` § Ethos & Delegation. Worker and
+evaluator are always distinct handles; Claude is the leader, never the
+evaluator. Use the `standard` pipeline for new commands or methodology
+changes, `quick` for compile fixes or single-section edits. A delegation
+still has to clear Loop 2's Verify and Local Review steps before it ships —
+delegating the drafting does not delegate the accountability.
+
+## What this doc is not
+
+It does not replace `CLAUDE.md`'s Quality Gates, CHANGELOG rules, Release
+Process, or Pre-PR Checklist — those stay where they are and this doc
+points to them rather than restating them. This doc is the *shape* of the
+loop; `CLAUDE.md`'s other sections are the *content* inside each step.


### PR DESCRIPTION
## Summary

- Adds `docs/WORKFLOW.md`: the three-loop development process (Backlog → PR → Delegation), `@`-imported from `CLAUDE.md` as mandatory reading — matching the pattern vox already uses.
- Rewrites `CLAUDE.md`'s Branch Discipline section so the "small fix" exemption is explicitly about the triviality of a single change, never about file count, and clarifies that "short-lived branch" never meant "no branch."
- Adds a T4 tier (genuinely trivial single-file fixes) to the Workflow Tiers table — T4 skips the bead, never the branch.
- Points the Pull Request and Code Review Workflow section at the new required Local Review step.

## Why

A 2026-08-30 session edited `prfaq.tex` and 8 files under `meetings/` directly on `main` — no bead, no branch, no local review, nothing committed for the whole working session. The root cause was one ambiguous sentence in the old Branch Discipline wording ("Small fixes... can go directly to main"), which was misread as license to skip the PR loop entirely for anything that felt mechanical. It never licensed that (branch protection already requires a PR for everything), but the wording didn't say so clearly enough. This PR closes that gap.

Fixes `prfaq-6wz`.

## Test plan

- [x] `make check` passes (compile + permission tests + prose-lint tests, 132/132) — unaffected by this docs-only change, confirmed unchanged
- [x] Both edited/new files re-read for internal consistency and correct cross-references (fixed one broken relative-path reference to the org-level `CLAUDE.md` during review)
- [x] Confirmed no CHANGELOG entry needed — CLAUDE.md changes are explicitly exempted under this repo's own existing CHANGELOG rule

Docs-only — Phase 3 verification (installed/run through real entry point) is N/A; verification is "the rendered doc reads correctly and is self-consistent," confirmed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to development workflow; no runtime, auth, or product behavior.
> 
> **Overview**
> **Closes a process loophole** that let multi-file work land on `main` without a branch, bead, or local review. **`docs/WORKFLOW.md`** is new mandatory reading (linked from `CLAUDE.md`) and defines **three loops**: backlog (beads/tiers), PR (branch → verify → document → **local review** → ship → close), and delegation nested in implement.
> 
> **`CLAUDE.md` branch discipline** no longer implies small fixes can skip the PR path: **everything merges via PR**; “short-lived branch” only describes lifetime, not skipping a branch. Multi-file or mechanical sweeps are explicitly **not** exempt from beads/branches. A new **T4 (Trivial)** tier may skip the bead but **never** the branch or Loop 2.
> 
> The **PR / code review** section now states that **local review runs before push**, with agent choices documented in Loop 2 (GitHub review is additive, not a substitute).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fdb4b4e262996996aff200b2ec4a07241ceda6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->