### PR TITLE
fix: redirect stdin on install.sh subprocess calls to survive piping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+### Fixed
+- **`install.sh` could break when piped, its only real distribution method.** None of its `claude`/`ssh` subprocess calls redirected stdin, so a subprocess reading even one byte from stdin during its own startup stole bytes from the same pipe `sh` was still reading its own remaining script source from, a classic `curl | sh` footgun. Every such invocation now redirects stdin from `/dev/null`. The existing test suite ran the installer as `sh install.sh <file>`, a mode that can never exhibit this bug since the script comes from the file and stdin is untouched; a new `tests/test_permissions.sh` section runs it via a real pipe under `sh`, `dash`, and `busybox sh` with a stdin-stealing stub `claude`, and fails 3/3 without the fix.
+
 ## [1.9.0] - 2026-08-30
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ info "Registering Punt Labs marketplace..."
 # source repo happens to contain it. Match a line that holds nothing but the
 # name (any leading decoration allowed) to read the name field alone.
 marketplace_listed() {
-  claude plugin marketplace list 2>/dev/null \
+  claude plugin marketplace list </dev/null 2>/dev/null \
     | grep -qE "^[^A-Za-z0-9]*[[:space:]]*${MARKETPLACE_NAME}[[:space:]]*$"
 }
 
@@ -63,14 +63,14 @@ marketplace_listed() {
 # is in fact registered. Registering again is then the recoverable path — if
 # add fails, look for the name anywhere in the listing before giving up.
 marketplace_mentioned() {
-  claude plugin marketplace list 2>/dev/null | grep -q "$MARKETPLACE_NAME"
+  claude plugin marketplace list </dev/null 2>/dev/null | grep -q "$MARKETPLACE_NAME"
 }
 
 # Every already-registered path has to refresh. Skipping it on one of them
 # resolves the install against whatever ref was cached last time, silently —
 # which is the failure this warning exists to surface.
 refresh_marketplace() {
-  if ! claude plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1; then
+  if ! claude plugin marketplace update "$MARKETPLACE_NAME" </dev/null >/dev/null 2>&1; then
     # Not fatal — the cached marketplace still resolves. But say so.
     warn "could not refresh the marketplace; installing from the cached copy"
     warn "if you end up on an old version, re-run this installer when back online"
@@ -80,7 +80,7 @@ refresh_marketplace() {
 if marketplace_listed; then
   ok "marketplace already registered"
   refresh_marketplace
-elif claude plugin marketplace add "$MARKETPLACE_REPO"; then
+elif claude plugin marketplace add "$MARKETPLACE_REPO" </dev/null; then
   ok "marketplace registered"
 elif marketplace_mentioned; then
   ok "marketplace already registered"
@@ -114,7 +114,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-if ! ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+if ! ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -T git@github.com </dev/null 2>&1 | grep -q "successfully authenticated"; then
   warn "SSH auth to GitHub unavailable, using HTTPS fallback"
   git config --global url."https://github.com/".insteadOf "git@github.com:"
   NEED_HTTPS_REWRITE=1
@@ -124,12 +124,12 @@ fi
 
 info "Installing $PLUGIN_NAME..."
 
-claude plugin uninstall "${PLUGIN_NAME}@${MARKETPLACE_NAME}" 2>/dev/null || true
-if ! claude plugin install "${PLUGIN_NAME}@${MARKETPLACE_NAME}"; then
+claude plugin uninstall "${PLUGIN_NAME}@${MARKETPLACE_NAME}" </dev/null 2>/dev/null || true
+if ! claude plugin install "${PLUGIN_NAME}@${MARKETPLACE_NAME}" </dev/null; then
   cleanup_https_rewrite
   fail "Failed to install $PLUGIN_NAME"
 fi
-if ! claude plugin list 2>/dev/null | grep -q "$PLUGIN_NAME@$MARKETPLACE_NAME"; then
+if ! claude plugin list </dev/null 2>/dev/null | grep -q "$PLUGIN_NAME@$MARKETPLACE_NAME"; then
   cleanup_https_rewrite
   fail "$PLUGIN_NAME install reported success but plugin not found"
 fi

--- a/tests/test_permissions.sh
+++ b/tests/test_permissions.sh
@@ -52,9 +52,11 @@ cat > "$WORK/bin/claude" <<'STUB'
 # reading its own remaining script text from. A CLI that reads even one byte
 # of stdin during startup (a first-run prompt, an update check) steals bytes
 # meant for sh's parser and corrupts everything after it. Consuming a chunk
-# here unconditionally makes every test using this stub exercise that
-# property, not just the piped-execution test below.
-dd bs=200 count=1 of=/dev/null 2>/dev/null || true
+# here makes every test using this stub exercise that property, not just
+# the piped-execution test below. Gated on stdin not being a terminal: on
+# an interactive run (stdin is a TTY, nothing is piped in) an unconditional
+# read here would block waiting for keyboard input and hang the suite.
+[ -t 0 ] || dd bs=200 count=1 of=/dev/null 2>/dev/null || true
 [ -n "${CLAUDE_STUB_LOG:-}" ] && echo "$*" >> "$CLAUDE_STUB_LOG"
 case "$*" in
   "plugin marketplace list")

--- a/tests/test_permissions.sh
+++ b/tests/test_permissions.sh
@@ -46,6 +46,15 @@ mkdir -p "$WORK/bin"
 # already-registered branch is never taken.
 cat > "$WORK/bin/claude" <<'STUB'
 #!/bin/sh
+# Every real invocation of `claude` inherits whatever install.sh's own stdin
+# is at the time -- and when the installer is piped (`curl ... | sh`, the
+# only way it is actually distributed), that is the *same pipe* sh is still
+# reading its own remaining script text from. A CLI that reads even one byte
+# of stdin during startup (a first-run prompt, an update check) steals bytes
+# meant for sh's parser and corrupts everything after it. Consuming a chunk
+# here unconditionally makes every test using this stub exercise that
+# property, not just the piped-execution test below.
+dd bs=200 count=1 of=/dev/null 2>/dev/null || true
 [ -n "${CLAUDE_STUB_LOG:-}" ] && echo "$*" >> "$CLAUDE_STUB_LOG"
 case "$*" in
   "plugin marketplace list")
@@ -280,6 +289,36 @@ fi
 STATUS=0
 run_installer "$H" none || STATUS=$?
 check "an empty marketplace list registers cleanly" "0" "$STATUS"
+
+printf '\nPiped execution safety (install.sh)\n'
+
+# install.sh is only ever distributed as `curl -fsSL <url> | sh` -- every
+# prior test above runs it as `sh install.sh <file>`, where the script comes
+# from the file and stdin is free for subprocesses to read. That mode can
+# never exercise the actual failure this section guards: when piped, sh
+# reads its own remaining source from the same fd a `claude`/`ssh` call
+# inherits, and any subprocess stdin read corrupts the parse. Run it via a
+# real pipe, through every POSIX sh implementation available, with the
+# stdin-stealing stub above -- a regression here means the installer breaks
+# for every real user, not just this test.
+H="$WORK/home-piped"
+mkdir -p "$H"
+
+for SH_IMPL in sh dash busybox; do
+  command -v "$SH_IMPL" >/dev/null 2>&1 || continue
+  [ "$SH_IMPL" = "busybox" ] && SH_IMPL="busybox sh"
+  rm -f "$WORK/claude-calls.log"
+  STATUS=0
+  # shellcheck disable=SC2086 # $SH_IMPL is a fixed, known-safe word list (sh|dash|"busybox sh")
+  env HOME="$H" PATH="$WORK/bin:$PATH" CLAUDE_STUB_MARKETPLACES=registered \
+    CLAUDE_STUB_LOG="$WORK/claude-calls.log" \
+    sh -c "cat '$REPO/install.sh' | $SH_IMPL" >"$WORK/installer-piped.out" 2>&1 || STATUS=$?
+  if [ "$STATUS" -eq 0 ] && grep -q "is ready!" "$WORK/installer-piped.out"; then
+    pass "piped through $SH_IMPL survives a stdin-stealing subprocess"
+  else
+    fail "piped through $SH_IMPL survives a stdin-stealing subprocess (exit $STATUS)"
+  fi
+done
 
 printf '\n%s passed, %s failed\n\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- `install.sh` is only ever distributed as `curl -fsSL <url> | sh`, and broke on a real machine: `sh: 217: Syntax error: end of file unexpected (expecting "fi")` right after the plugin install step.
- Root cause: when piped, `sh` reads its own remaining script text from the same pipe fd that `claude`/`ssh` subprocess calls inherit as their stdin. None of those calls redirected stdin, so a subprocess reading even one byte from stdin during its own startup steals bytes meant for `sh`'s parser, corrupting everything parsed after that point. Classic `curl | sh` footgun.
- Fix: every `claude`/`ssh` invocation now redirects stdin from `/dev/null` (none of them need real stdin).

## Why the existing tests never caught this

Every prior install.sh test runs it as `sh install.sh <file>` — script content comes from the file, stdin is untouched, and this bug class is structurally impossible to hit that way. Real-world usage is always piped. Added a new "Piped execution safety" section to `tests/test_permissions.sh` that runs the installer through an actual pipe (`cat install.sh | $SH_IMPL`) under `sh`, `dash`, and `busybox sh`, with a stub `claude` that deliberately consumes a stdin chunk on every call (mimicking a first-run prompt or update check).

## Test plan

- [x] Reproduced the bug class locally: piped the pre-fix script through `busybox sh` with the stdin-stealing stub — genuine shell syntax error (different exact message than the user's report, same class: runtime parse corruption after a subprocess touches stdin).
- [x] Confirmed the fix resolves it: same harness, same stub, fixed script runs cleanly through to `is ready!` under `sh`, `dash`, and `busybox sh`.
- [x] Proved the new test is meaningful, not just trivially passing: reverted the fix temporarily, re-ran the suite — new test fails 3/3 shells (`exit 2` each). Restored the fix — passes 3/3.
- [x] `make check` — full suite green (62 permission tests including the 3 new ones, 132 prose-lint tests, 5 `.tex` compiles).
- [x] CHANGELOG entry added under `[Unreleased]` → `### Fixed`.

Fixes `prfaq-vut` (P0 — the installer was broken for real users on the currently-pinned SHA).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow installer-only change: subprocess stdin is detached from the pipe while behavior of `claude`/`ssh` calls is unchanged for normal use.
> 
> **Overview**
> Fixes a **P0 installer failure** when users run the script the way it is distributed (`curl … | sh`): `sh` and child `claude`/`ssh` processes shared the same stdin pipe, so any subprocess that read stdin during startup could truncate the script mid-parse and surface errors like unexpected EOF before `fi`.
> 
> **`install.sh`** now passes **`</dev/null`** on every `claude` and `ssh` invocation (marketplace list/add/update, plugin install/uninstall/list, GitHub SSH probe). None of those steps need real stdin.
> 
> **`tests/test_permissions.sh`** extends the stub `claude` to consume a stdin chunk when stdin is not a TTY (miricking prompts/update checks without hanging interactive runs), and adds a **“Piped execution safety”** block that runs `cat install.sh | sh|dash|busybox sh` and asserts the installer still reaches **`is ready!`**. Prior tests only used `sh install.sh <file>`, which never hit this bug class.
> 
> **`CHANGELOG.md`** records the fix under `[Unreleased]` → **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3f9177e153789d077e8318b7ebb90aaddb16b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->