### PR TITLE
chore: pin README install.sh SHA to ba3a949

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A product discovery document without evidence is fiction. `prfaq` starts from yo
 1. **Install** the plugin:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/27def5c/install.sh | sh
+   curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/ba3a949/install.sh | sh
    ```
 
    <details>
@@ -32,7 +32,7 @@ A product discovery document without evidence is fiction. `prfaq` starts from yo
    <summary>Verify before running</summary>
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/27def5c/install.sh -o install.sh
+   curl -fsSL https://raw.githubusercontent.com/punt-labs/prfaq/ba3a949/install.sh -o install.sh
    shasum -a 256 install.sh
    cat install.sh
    sh install.sh


### PR DESCRIPTION
## Summary
- Repoints both `install.sh` SHA references in `README.md` from `27def5c` (broken under piped execution, prfaq-vut) to `ba3a949`, the commit that fixed it (#81).

## Test plan
- [x] Confirmed `ba3a949` is the real squash-merge commit for #81.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only SHA pin change with no runtime or security logic changes.
> 
> **Overview**
> Updates **Quick Start** install documentation so both `curl` examples fetch `install.sh` from commit **`ba3a949`** instead of **`27def5c`**.
> 
> That repoints copy-paste installs (direct pipe and verify-then-run) at the commit that fixed piped `install.sh` execution, so new users no longer pull the broken script referenced by the old SHA pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8e151574db9f9ef0e62b48233bb16e2387a4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->