### PR TITLE
ci: add workflow that runs make check on every push/PR

### DIFF
--- a/.github/workflows/biff-notify.yml
+++ b/.github/workflows/biff-notify.yml
@@ -5,7 +5,7 @@ on:
     # filename. `biff enable` renders this list from the target repo's own
     # .github/workflows/*.yml and *.yaml name: fields, so a fixed list can't
     # watch the wrong workflows in a repo whose names differ from biff's.
-    workflows: ["Docs"]
+    workflows: ["Check", "Docs"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,22 @@
+name: Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install jq and a full TeX distribution
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends jq texlive-full biber
+
+      - name: make check
+        run: make check


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/check.yml`: installs `jq`, `texlive-full`, and `biber`, then runs `make check` (every `.tex` compile, the full permission test suite including the new piped-execution regression section, and the prose-lint suite) on every push/PR to `main`.

## Why

Zero CI coverage existed for `install.sh`, the permission test suite, or the prose-lint suite before this — `.github/workflows/` only had `docs.yml` (markdownlint) and `biff-notify.yml` (unrelated notification hook). The install.sh stdin-theft bug (prfaq-vut, fixed in #81) shipped broken specifically because nothing automated ever exercised it — only a human running `make check` locally would have caught it, and that didn't happen before it shipped. Requested directly: "You need CI that tells you whether your installer works."

## Test plan

- [x] Workflow structure matches the existing `docs.yml` pattern (same trigger conditions, same pinned `actions/checkout` SHA).
- [x] `make check` already verified passing locally (62 permission tests, 132 prose-lint tests, 5 `.tex` compiles) — this PR's own CI run is the first real end-to-end validation of the workflow itself.
- Docs-only/CI-only change — no CHANGELOG entry per this repo's own rule (internal-only changes are exempt).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds quality gates; no production code, auth, or data-handling paths are modified.
> 
> **Overview**
> Adds automated CI that runs **`make check`** on every push and PR to **`main`**, covering TeX compiles, permission/install tests, and prose-lint—areas that previously had no workflow coverage.
> 
> The new **`.github/workflows/check.yml`** workflow mirrors **`docs.yml`** triggers and pins the same **`actions/checkout`** revision, then installs **`jq`**, **`texlive-full`**, and **`biber`** before invoking **`make check`**. **`biff-notify.yml`** is updated so Biff failure notifications also watch the **`Check`** workflow (alongside **`Docs`**), without changing the existing push-only secret-safety filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec835ae0534525f60eb13030106756c316c14bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->