### PR TITLE
ci: verify the product install end-to-end on every supported OS

### DIFF
--- a/.github/workflows/biff-notify.yml
+++ b/.github/workflows/biff-notify.yml
@@ -5,7 +5,7 @@ on:
     # filename. `biff enable` renders this list from the target repo's own
     # .github/workflows/*.yml and *.yaml name: fields, so a fixed list can't
     # watch the wrong workflows in a repo whose names differ from biff's.
-    workflows: ["Check", "Docs"]
+    workflows: ["Check", "Docs", "Pinned Install"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,7 +60,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             texlive-latex-recommended texlive-latex-extra \
             texlive-fonts-recommended texlive-fonts-extra \
-            texlive-pictures texlive-bibtex-extra biber
+            texlive-pictures texlive-bibtex-extra \
+            texlive-plain-generic biber
       - name: Compile every shipped .tex
         run: make test
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,6 +29,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Ensure jq (the permission suite hard-requires it)
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            if command -v apt-get >/dev/null 2>&1; then
+              sudo apt-get update && sudo apt-get install -y --no-install-recommends jq
+            else
+              brew install jq
+            fi
+          fi
       - name: Permission and installer test suites
         run: make test-perms
       - name: Prose-lint test suite
@@ -58,33 +67,38 @@ jobs:
   # The actual product install, end to end, with the REAL claude CLI — not
   # the stub the test suite uses. Pipes install.sh through sh exactly as
   # the documented `curl | sh` does, registers the real marketplace,
-  # installs the real plugin, and asserts it is listed. The toolchain
-  # matrix covers the installer's detection branches: tex-only,
-  # pandoc-only, and neither (the warn-and-continue path).
+  # installs the real plugin, and asserts it is listed. Full matrix: every
+  # supported OS crossed with every toolchain detection branch — tex-only,
+  # pandoc-only, and neither (the warn-and-continue path). The tex+pandoc
+  # combination has no code path of its own (it is the two success
+  # branches with no warning), so it is not a separate leg.
   install-e2e:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-24.04
-            toolchain: pandoc
-          - os: ubuntu-24.04
-            toolchain: tex
-          - os: macos-latest
-            toolchain: none
+        os: [ubuntu-24.04, macos-latest]
+        toolchain: [tex, pandoc, none]
     name: install-e2e (${{ matrix.os }}, ${{ matrix.toolchain }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install the real claude CLI
         run: npm install -g @anthropic-ai/claude-code
-      - name: Install pandoc only
-        if: matrix.toolchain == 'pandoc'
+      - name: Install pandoc only (Linux)
+        if: matrix.toolchain == 'pandoc' && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pandoc
-      - name: Install a minimal TeX only
-        if: matrix.toolchain == 'tex'
+      - name: Install pandoc only (macOS)
+        if: matrix.toolchain == 'pandoc' && runner.os == 'macOS'
+        run: brew install pandoc
+      - name: Install a minimal TeX only (Linux)
+        if: matrix.toolchain == 'tex' && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-base biber
+      - name: Install a minimal TeX only (macOS)
+        if: matrix.toolchain == 'tex' && runner.os == 'macOS'
+        run: |
+          brew install --cask basictex
+          echo "/Library/TeX/texbin" >> "$GITHUB_PATH"
       - name: Run the installer exactly as users do (piped through sh)
         run: cat install.sh | sh
       - name: Assert the plugin is actually installed

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,17 +9,83 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+  # Shell-behavior and hook suites on every supported OS. These are the
+  # OS-sensitive tests: macOS /bin/sh is bash in POSIX mode with BSD
+  # userland, Ubuntu's is dash with GNU userland — the difference that made
+  # the install.sh stdin-theft bug (prfaq-vut) shell-dependent. No TeX
+  # needed here, so both legs finish in about a minute.
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest]
+    name: tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Permission and installer test suites
+        run: make test-perms
+      - name: Prose-lint test suite
+        run: make test-prose
 
-      - name: Install jq and a full TeX distribution
+  # The compile gate. TeX output is not OS-dependent, so one OS suffices;
+  # what matters is that every shipped .tex compiles. Installs the specific
+  # collections the documents need instead of texlive-full (~4 GB) — if a
+  # package is missing the compile fails loudly, so the slim set is
+  # self-verifying.
+  compile:
+    name: compile
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install TeX packages the documents use
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends jq texlive-full biber
+          sudo apt-get install -y --no-install-recommends \
+            texlive-latex-recommended texlive-latex-extra \
+            texlive-fonts-recommended texlive-fonts-extra \
+            texlive-pictures texlive-bibtex-extra biber
+      - name: Compile every shipped .tex
+        run: make test
 
-      - name: make check
-        run: make check
+  # The actual product install, end to end, with the REAL claude CLI — not
+  # the stub the test suite uses. Pipes install.sh through sh exactly as
+  # the documented `curl | sh` does, registers the real marketplace,
+  # installs the real plugin, and asserts it is listed. The toolchain
+  # matrix covers the installer's detection branches: tex-only,
+  # pandoc-only, and neither (the warn-and-continue path).
+  install-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            toolchain: pandoc
+          - os: ubuntu-24.04
+            toolchain: tex
+          - os: macos-latest
+            toolchain: none
+    name: install-e2e (${{ matrix.os }}, ${{ matrix.toolchain }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install the real claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Install pandoc only
+        if: matrix.toolchain == 'pandoc'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pandoc
+      - name: Install a minimal TeX only
+        if: matrix.toolchain == 'tex'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-base biber
+      - name: Run the installer exactly as users do (piped through sh)
+        run: cat install.sh | sh
+      - name: Assert the plugin is actually installed
+        run: claude plugin list | grep -q "prfaq@punt-labs"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,6 +79,20 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-latest]
         toolchain: [tex, pandoc, none]
+        # Each leg asserts the installer's own detection message for its
+        # toolchain state, so a leg cannot pass with the wrong branch
+        # having fired (e.g. a preinstalled pandoc silently turning the
+        # tex leg into the pandoc branch).
+        include:
+          - toolchain: tex
+            expect: "pdflatex found (PDF output available)"
+            forbid: "pandoc found (DOCX export available)"
+          - toolchain: pandoc
+            expect: "pandoc found (DOCX export available)"
+            forbid: "pdflatex found (PDF output available)"
+          - toolchain: none
+            expect: "Neither pandoc nor TeX found"
+            forbid: ""
     name: install-e2e (${{ matrix.os }}, ${{ matrix.toolchain }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -86,21 +100,51 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install the real claude CLI
         run: npm install -g @anthropic-ai/claude-code
+      - name: Remove preinstalled pandoc (runner images may ship one)
+        if: matrix.toolchain != 'pandoc'
+        run: |
+          while p=$(command -v pandoc); do
+            sudo rm -f "$p"
+          done
+          true
       - name: Install pandoc only (Linux)
         if: matrix.toolchain == 'pandoc' && runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends pandoc
+        run: |
+          if ! command -v pandoc >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends pandoc
+          fi
       - name: Install pandoc only (macOS)
         if: matrix.toolchain == 'pandoc' && runner.os == 'macOS'
-        run: brew install pandoc
+        run: |
+          if ! command -v pandoc >/dev/null 2>&1; then
+            brew install pandoc
+          fi
       - name: Install a minimal TeX only (Linux)
         if: matrix.toolchain == 'tex' && runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-base biber
+        # texlive-latex-base, not texlive-base: /usr/bin/pdflatex is in
+        # the former (dpkg -S ground truth); the latter alone leaves the
+        # installer's TeX detection finding nothing.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-latex-base biber
       - name: Install a minimal TeX only (macOS)
         if: matrix.toolchain == 'tex' && runner.os == 'macOS'
         run: |
           brew install --cask basictex
           echo "/Library/TeX/texbin" >> "$GITHUB_PATH"
       - name: Run the installer exactly as users do (piped through sh)
-        run: cat install.sh | sh
+        run: |
+          set -o pipefail
+          cat install.sh | sh 2>&1 | tee install-out.txt
+      - name: Assert the intended toolchain branch actually fired
+        env:
+          EXPECT: ${{ matrix.expect }}
+          FORBID: ${{ matrix.forbid }}
+        run: |
+          grep -F "$EXPECT" install-out.txt
+          if [ -n "$FORBID" ]; then
+            if grep -F "$FORBID" install-out.txt; then
+              echo "Forbidden detection message present — wrong branch fired" >&2
+              exit 1
+            fi
+          fi
       - name: Assert the plugin is actually installed
         run: claude plugin list | grep -q "prfaq@punt-labs"

--- a/.github/workflows/pinned-install.yml
+++ b/.github/workflows/pinned-install.yml
@@ -32,11 +32,16 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install the real claude CLI
         run: npm install -g @anthropic-ai/claude-code
-      - name: Run the README's documented install command verbatim
+      - name: Run the README's documented install command
+        # Downloaded to a file first so a network/404 failure is
+        # distinguishable from a script failure, then still fed to sh
+        # through a pipe — the piped-execution semantics are the exact
+        # property this test exists to exercise (prfaq-vut).
         run: |
-          URL=$(grep -o 'https://raw\.githubusercontent\.com/punt-labs/prfaq/[a-f0-9]*/install\.sh' README.md | head -1)
-          test -n "$URL" || { echo "No pinned install.sh URL found in README.md" >&2; exit 1; }
+          URL=$(grep -Eo 'https://raw\.githubusercontent\.com/punt-labs/prfaq/[a-f0-9]{7,40}/install\.sh' README.md | head -1)
+          test -n "$URL" || { echo "No SHA-pinned install.sh URL found in README.md" >&2; exit 1; }
           echo "Testing pinned URL: $URL"
-          curl -fsSL "$URL" | sh
+          curl -fsSL "$URL" -o pinned-install.sh
+          cat pinned-install.sh | sh
       - name: Assert the plugin is actually installed
         run: claude plugin list | grep -q "prfaq@punt-labs"

--- a/.github/workflows/pinned-install.yml
+++ b/.github/workflows/pinned-install.yml
@@ -1,0 +1,42 @@
+name: Pinned Install
+
+# Users do not run the repo's current install.sh — they run the SHA-pinned
+# copy the README (and the website) tell them to curl. PR CI can never see
+# that copy break, which is exactly how the prfaq-vut installer bug reached
+# a real user first. This workflow runs the documented command verbatim on
+# every supported OS, nightly and on demand, parsing the URL out of
+# README.md itself so the test can never drift from what is documented.
+#
+# Note: biff CI notifications fire only for push-event runs, so a scheduled
+# failure here surfaces via GitHub's own scheduled-workflow failure email
+# and the Actions tab, not via biff.
+
+on:
+  schedule:
+    - cron: '43 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pinned-install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest]
+    name: pinned-install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install the real claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run the README's documented install command verbatim
+        run: |
+          URL=$(grep -o 'https://raw\.githubusercontent\.com/punt-labs/prfaq/[a-f0-9]*/install\.sh' README.md | head -1)
+          test -n "$URL" || { echo "No pinned install.sh URL found in README.md" >&2; exit 1; }
+          echo "Testing pinned URL: $URL"
+          curl -fsSL "$URL" | sh
+      - name: Assert the plugin is actually installed
+        run: claude plugin list | grep -q "prfaq@punt-labs"

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ prfaq: ## Compile .tex to .pdf and clean artifacts
 	@for f in $(TEX_FILES); do \
 	  echo "Compiling $$f ..."; \
 	  dir=$$(dirname "$$f"); base=$$(basename "$$f" .tex); \
+	  rm -f "$$dir/$$base.pdf"; \
 	  pdflatex -interaction=nonstopmode -output-directory="$$dir" "$$f" > /dev/null 2>&1; \
 	  if [ -f "$$dir/$$base.bib" ] && command -v biber > /dev/null 2>&1; then \
 	    (cd "$$dir" && biber "$$base") > /dev/null 2>&1 || true; \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,14 @@ prfaq: ## Compile .tex to .pdf and clean artifacts
 	  if [ -f "$$dir/$$base.pdf" ]; then \
 	    echo "  $$dir/$$base.pdf"; \
 	  else \
-	    echo "Error: $$f failed to compile" >&2; exit 1; \
+	    echo "Error: $$f failed to compile" >&2; \
+	    if [ -f "$$dir/$$base.log" ]; then \
+	      echo "--- first errors from $$dir/$$base.log ---" >&2; \
+	      grep -A3 '^!' "$$dir/$$base.log" | head -40 >&2; \
+	      echo "--- tail of $$dir/$$base.log ---" >&2; \
+	      tail -25 "$$dir/$$base.log" >&2; \
+	    fi; \
+	    exit 1; \
 	  fi; \
 	done
 	@rm -f $(LATEX_ARTIFACTS)


### PR DESCRIPTION
## Summary

The prior Check workflow proved `make check` passes on Ubuntu — and nothing else. No macOS coverage (a supported platform whose `/bin/sh` is bash-in-POSIX-mode with BSD userland, the exact axis the prfaq-vut installer bug varied on), the installer only ever tested against a **stub** `claude` CLI, exactly one toolchain configuration, and nothing watching the SHA-pinned `install.sh` copy users actually download.

**Check workflow, restructured into parallel jobs:**
- `tests (ubuntu-24.04)` / `tests (macos-latest)` — permission/installer + prose suites on both supported OSes; no TeX needed, ~1 min each
- `compile` — the `.tex` gate on Ubuntu using the specific TeX collections the documents need instead of `texlive-full` (~4 GB); a missing package fails the compile loudly, so the slim set is self-verifying
- `install-e2e` — the real product install with the **real** `claude` CLI, piped through `sh` exactly as the documented `curl | sh` does, across toolchain configs (tex-only, pandoc-only, none) on both OSes, asserting `claude plugin list` shows `prfaq@punt-labs`
- `concurrency` cancel-in-progress + per-job timeouts

**New `Pinned Install` workflow** (nightly + `workflow_dispatch`): parses the pinned install.sh URL out of `README.md` itself and runs it verbatim on both OSes — the copy users actually run, which PR CI structurally cannot see break. `biff-notify.yml` regenerated via `biff enable` to watch it.

Wall-clock stays at or under the previous ~6 min: the slow compile job runs in parallel and drops `texlive-full`.

## Test plan

- [x] **Spiked headless `claude` first** (design gate): `claude plugin marketplace add` + `plugin install` + `plugin list` all succeed under a fresh `HOME` with zero auth — verified before writing the workflow
- [x] README URL parse verified locally: extracts `https://raw.githubusercontent.com/punt-labs/prfaq/ba3a949/install.sh`
- [x] All three workflow files YAML-validated; `make test-perms` (62/62) and `make test-prose` (132/132) pass locally
- [ ] **This PR's own CI run is the acceptance test**: all 6 new job legs must pass on real runners — including the first macOS runs this repo has ever had — before merge
- After merge: update the branch-protection ruleset to require the new job contexts, and `workflow_dispatch` the Pinned Install workflow once to prove it green

Part of `prfaq-sv7`. CI-only change — no CHANGELOG entry per this repo's rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Makefile diagnostics only; no runtime product, auth, or data-path changes.
> 
> **Overview**
> Replaces the single **Check** job with parallel **tests** (Ubuntu + macOS permission/prose suites), a **compile** job that uses targeted TeX packages instead of `texlive-full`, and **install-e2e** legs that pipe `install.sh` through `sh` with the real `claude` CLI across tex / pandoc / none toolchain setups on both OSes, including grep checks that the right installer detection branch ran.
> 
> Adds a **Pinned Install** workflow (nightly + manual) that extracts the SHA-pinned `install.sh` URL from `README.md` and runs it on both OSes, and registers that workflow in **biff-notify**. **Check** also gets `concurrency` cancel-in-progress.
> 
> The **Makefile** `prfaq` target now deletes stale PDFs before compiling and prints LaTeX log excerpts when a build fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77d5664e19cacb4309b280322208da12de0d91e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->