### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-08-30
+
 ### Fixed
 - **`install.sh` could break when piped, its only real distribution method.** None of its `claude`/`ssh` subprocess calls redirected stdin, so a subprocess reading even one byte from stdin during its own startup stole bytes from the same pipe `sh` was still reading its own remaining script source from, a classic `curl | sh` footgun. Every such invocation now redirects stdin from `/dev/null`. The existing test suite ran the installer as `sh install.sh <file>`, a mode that can never exhibit this bug since the script comes from the file and stdin is untouched; a new `tests/test_permissions.sh` section runs it via a real pipe under `sh`, `dash`, and `busybox sh` with a stdin-stealing stub `claude`, and fails 3/3 without the fix.
 
@@ -379,7 +381,8 @@ First tagged release.
 - Plugin cache not clearing on reinstall (stale cache hid new agents)
 - FAQ paragraph indentation inconsistency in `faqpair` environment
 
-[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/punt-labs/prfaq/compare/v1.9.1...HEAD
+[1.9.1]: https://github.com/punt-labs/prfaq/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/punt-labs/prfaq/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/punt-labs/prfaq/compare/v1.7.3...v1.8.0
 [1.7.3]: https://github.com/punt-labs/prfaq/compare/v1.7.2...v1.7.3

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prfaq-dev",
   "description": "Amazon Working Backwards PR/FAQ process \u2014 generate professional LaTeX documents for product discovery and decision-making",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"


### PR DESCRIPTION
## Summary

Patch release carrying the install.sh piped-execution fix (#81) to users.

- `plugin.json`: version `1.9.0` → `1.9.1` (dev name kept — the prod-name swap happens only in the local tagged commit after this merges, per the documented release process; the `punt release` CLI is not used because it swaps the name on the release branch, `pkit-pd5n`)
- `CHANGELOG.md`: `[Unreleased]` → `[1.9.1] - 2026-08-30`, compare links updated

## Test plan

- [x] `make check` passes locally (62 permission tests, 132 prose-lint tests, all `.tex` compile)
- [ ] This PR is the first to face the full 10-context required-checks gate added in #84 — all legs must pass to merge

After merge: local name-swap + tag `v1.9.1` + dev restore, push tag only, GitHub Release, marketplace pin PR, website version PR, `.github` two-step re-pin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only edits to version and changelog; no runtime or installer logic changes in this diff.
> 
> **Overview**
> **Patch release packaging** for v1.9.1: bumps `plugin/.claude-plugin/plugin.json` from **1.9.0** to **1.9.1** (dev plugin name unchanged until the post-merge tag step).
> 
> **CHANGELOG** cuts the shipped fix out of `[Unreleased]` into **`[1.9.1] - 2026-08-30`**: the documented change is the **`install.sh` piped-install fix** (redirect `claude`/`ssh` subprocess stdin from `/dev/null` so `curl | sh` cannot lose script bytes, plus pipe-based tests under `sh`/`dash`/`busybox sh`). Compare links now point `[Unreleased]` at `v1.9.1...HEAD` and add the `v1.9.0...v1.9.1` release link.
> 
> This PR diff does **not** include installer or test code—only version and changelog—assuming the fix already landed on the branch (e.g. #81).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916f0d07a41decdd0da14f95a6260660718c4b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->