### PR TITLE
fix(release): drop the skip-ci marker from the release-prep commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the prfaq plugin are documented here. This project follow
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release-prep commits no longer carry `[skip ci]`.** `scripts/release-plugin.sh` stamped `[skip ci]` into the commit that becomes the HEAD of the release PR, which suppressed all CI on that PR — releases merged unverified, and any required-checks rule would deadlock waiting for checks that could never run (the same defect class observed on ethos#496).
+
 ## [1.9.1] - 2026-08-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,9 +176,14 @@ Branch protection is active, so every step that touches main goes through a PR.
    # (use scripts/release-plugin.sh if working tree is clean,
    #  or edit plugin.json manually if untracked files exist)
    git add plugin/.claude-plugin/plugin.json
-   git commit --no-verify -m "chore: prepare plugin for release [skip ci]"
+   git commit --no-verify -m "chore: prepare plugin for release"
    git tag vX.Y.Z
    ```
+
+   Never put `[skip ci]` (or any CI-skip marker) in this commit message: GitHub
+   honors the marker anywhere in a head commit message, so it suppresses all CI
+   on the release PR and deadlocks required-checks rules (defect class observed
+   on ethos#496).
 
 7. **Restore the dev name** immediately:
    ```bash

--- a/scripts/release-plugin.sh
+++ b/scripts/release-plugin.sh
@@ -64,4 +64,4 @@ if [[ ${#dev_files[@]} -gt 0 ]]; then
   git -C "$REPO_ROOT" rm "${dev_files[@]}"
 fi
 
-git -C "$REPO_ROOT" commit --no-verify -m "chore: prepare plugin for release [skip ci]"
+git -C "$REPO_ROOT" commit --no-verify -m "chore: prepare plugin for release"


### PR DESCRIPTION
## Summary

`scripts/release-plugin.sh` committed the release-prep changes with `chore: prepare plugin for release [skip ci]`. That commit becomes the HEAD of the release PR itself, so `[skip ci]` guaranteed **no CI ever ran on the release PR**.

## Defect class

Same class of deadlock/blind-merge defect observed on ethos#496 during the ethos v4.16.1 release:

- Release tooling that waits for checks on the release PR waits forever — `[skip ci]` guarantees the checks will never run.
- Any required-checks ruleset can never be satisfied, deadlocking the release.
- Without required checks, the release PR merges completely unverified.

## Change

- Remove ` [skip ci]` from the release-prep commit message in `scripts/release-plugin.sh` (everything else unchanged).
- CHANGELOG entry under `## [Unreleased]` / `### Fixed`.

## Verification

script+docs only — verified with shellcheck + markdownlint:

- `shellcheck scripts/release-plugin.sh` — clean
- `npx --yes markdownlint-cli2 CHANGELOG.md` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)